### PR TITLE
Tb/simple esx service management

### DIFF
--- a/lib/puppet/provider/esx_shells/default.rb
+++ b/lib/puppet/provider/esx_shells/default.rb
@@ -1,0 +1,70 @@
+require 'lib/puppet/provider/vcenter'
+
+Puppet::Type.type(:esx_shells).provide(:esx_shells, :parent => Puppet::Provider::Vcenter) do
+  @doc = "Manages vCenter hosts' ESXi Shell and SSH configuration."
+
+  def initialize(args)
+    @prefix       = 'UserVars.'
+    @changed_value = []
+
+    # TODO: we lose camelcase when properties are created.
+    @propmap = {
+      :esxi_shell_time_out            => 'ESXiShellTimeOut',
+      :esxi_shell_interactive_time_out => 'ESXiShellInteractiveTimeOut',
+      :suppress_shell_warning        => 'SuppressShellWarning',
+    }
+    @propmap.each_pair do |k, v| @propmap[k] = (@prefix + v).to_sym end
+
+    super(args)
+  end
+
+
+  Puppet::Type.type(:esx_shells).properties.collect{|x| x.name}.each do |prop|
+    define_method(prop) do
+      key = @propmap[prop] || prop
+      if config.include? key
+        value = config[key]
+      else
+        Puppet.debug "ESX shells #{resource[:name]} -- get failed for " +
+            "property/key '#{prop}'/'#{key}' in object '#{config.inspect}'"
+        fail "property '#{prop}' not found in map"
+      end
+    end
+
+    define_method("#{prop}=") do |value|
+      Puppet.debug "ESX shells #{resource[:name]} -- set " +
+          "property/key '#{prop}'/'#{@propmap[prop]}' " +
+          "to '#{value.inspect}'"
+      # TODO: rbvmomi automatically cast numbers to long, and we need to query
+      # the property and do this manually for RbVmomi::BasicTypes::Int.new.
+      # This is pending Ruby 1.8.7 fix.
+      @changed_value << { :key => "#{@propmap[prop] || prop}", :value => value }
+    end
+  end
+
+  def flush
+    unless @changed_value.empty?
+      begin
+        host.configManager.advancedOption.UpdateOptions(:changedValue => @changed_value)
+      rescue Exception => e
+        raise Puppet::Error, "UpdateOptions failed: #{e.argument}"
+      end
+    end
+  end
+
+  private
+
+  def config
+    @config ||= key_value(host.config.option, @prefix)
+  end
+
+  def key_value(object, prefix)
+    subset = object.select{ |x| x.key=~ /^#{Regexp.escape(prefix)}/ }
+    result = Hash[* subset.collect{ |x| [x.key.to_sym, x.value] }.flatten ]
+  end
+
+  def host
+    @host ||= vim.searchIndex.FindByDnsName(:dnsName => resource[:host], :vmSearch => false)
+  end
+end
+

--- a/lib/puppet/type/esx_shells.rb
+++ b/lib/puppet/type/esx_shells.rb
@@ -1,0 +1,42 @@
+Puppet::Type.newtype(:esx_shells) do
+  @doc = "Manage vCenter esx hosts config for shells (ESXi Shell and SSH)"
+
+  newparam(:host, :namevar => true) do
+    desc "ESX hostname or ip address."
+  end
+
+  newproperty(:suppress_shell_warning) do
+    desc ""
+    newvalues('0', '1')
+    defaultto(0)
+
+    munge do |value|
+      Integer(value)
+    end
+  end
+
+  newproperty(:esxi_shell_time_out) do
+    desc ""
+    newvalues(/\d+/)
+    defaultto(0)
+
+    munge do |value|
+      Integer(value)
+    end
+  end
+
+  newproperty(:esxi_shell_interactive_time_out) do
+    desc ""
+    newvalues(/\d+/)
+    defaultto(0)
+
+    munge do |value|
+      Integer(value)
+    end
+  end
+
+  autorequire(:vc_host) do
+    # autorequire esx host.
+    self[:name]
+  end
+end

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -4,10 +4,12 @@ define vcenter::host (
   $username,
   $password,
   $dateTimeConfig = {},
+  $shells = {},
+  $servicesConfig = {},
   # transport is a metaparameter
 ) {
 
-  $default = {
+  $default_dt = {
     ntpConfig => {
       running => true,
       policy => 'automatic',
@@ -17,8 +19,30 @@ define vcenter::host (
       key => 'UTC',
     },
   }
+  $config_dt = merge($default_dt, $dateTimeConfig)
 
-  $dtconf = merge($default, $dateTimeConfig)
+  $default_shell = {
+    esxi_shell => {
+      running => false,
+      policy => 'off',
+    },
+    ssh => {
+      running => false,
+      policy => 'off',
+    },
+    esxi_shell_time_out => 0,
+    esxi_shell_interactive_time_out => 0,
+    suppress_shell_warning => 0,
+  }
+  $config_shells = merge($default_shell, $shells)
+
+  $default_svcs = {
+    dcui => {
+      running => true,
+      policy => 'on',
+    },
+  }
+  $config_svcs = merge($default_svcs, $servicesConfig)
 
   vc_host { $name:
     ensure    => present,
@@ -28,15 +52,52 @@ define vcenter::host (
     transport => $transport,
   }
 
+  # ntp
   esx_ntpconfig { $name:
-    server    => $dtconf['ntpConfig']['server'],
+    server    => $config_dt['ntpConfig']['server'],
     transport => $transport,
   }
 
-  # We do not need to manage the enure state.
   esx_service { "${name}:ntpd":
-    policy  => $dtconf['ntpConfig']['policy'],
-    running => $dtconf['ntpConfig']['running'],
+    policy  => $config_dt['ntpConfig']['policy'],
+    running => $config_dt['ntpConfig']['running'],
     subscribe => Esx_ntpconfig[$name],
+  }
+
+  # shells
+  esx_shells { $name:
+    # to disable cluster/host status warnings: 
+    #   http://kb.vmware.com/kb/2034841 ESXi 5.1 and related articles
+    #   esxcli system settings advanced set -o /UserVars/SuppressShellWarning -i (0|1)
+    #   vSphere API: advanced settings UserVars.SuppressShellWarning = (0|1) [type long]
+    suppress_shell_warning => $config_shells['suppress_shell_warning'],
+    # timeout means 'x minutes after enablement, disable new logins'
+    #   vSphere API: advanced settings UserVars.ESXiShellTimeOut = [type long] (0 disables)
+    #   http://kb.vmware.com/kb/2004746 ; timeout isn't 'log out user after x minutes inactivity'
+    esxi_shell_time_out  => $config_shells['esxi_shell_time_out'],
+    # interactiveTimeOut means 'log out user after x minutes inactivity'
+    #   vSphere API: advanced settings UserVars.ESXiShellInteractiveTimeOut = [type long] (0 disables)
+    esxi_shell_interactive_time_out  => $config_shells['esxi_shell_interactive_time_out'],
+    transport => $transport,
+  }
+
+  esx_service { "${name}:TSM":
+    policy  => $config_shells['esxi_shell']['policy'],
+    running => $config_shells['esxi_shell']['running'],
+    subscribe => Esx_shells[$name],
+  }
+  esx_service { "${name}:TSM-SSH":
+    policy  => $config_shells['ssh']['policy'],
+    running => $config_shells['ssh']['running'],
+    subscribe => Esx_shells[$name],
+  }
+
+  # simple services
+  # - fully managed by HostServiceSystem 
+  # - behaviors are boot-time enablement and running/stopped
+  # - vSphere API provides no additional configuration
+  esx_service { "${name}:DCUI":
+    policy  => $config_svcs['dcui']['policy'],
+    running => $config_svcs['dcui']['running'],
   }
 }


### PR DESCRIPTION
Combines management of ESXi Shell and SSH for ESX. They share 3 configuration parameters (ESXiShellTimeOut, ESXiShellInteractiveTimeOut, and SuppressShellWarning). 

Adds DCUI (Direct Console User Interface) management.

Sets expected defaults in manifests/hosts.pp for these services

Uses snake_case for parameters but does not yet use generic snake_case/camelCase conversion.
