### PR TITLE
Update vShield REST requests to support multiple version.

### DIFF
--- a/lib/puppet/provider/vshield.rb
+++ b/lib/puppet/provider/vshield.rb
@@ -18,19 +18,18 @@ class Puppet::Provider::Vshield <  Puppet::Provider
     @transport.rest
   end
 
-  def get(url)
-    result = Nori.parse(rest[url].get)
-    Puppet.debug "VShield REST get #{url} result:\n#{result.inspect}"
-    result
+  [:get, :delete].each do |m|
+    define_method(m) do |url|
+      result = Nori.parse(rest[url].send(m))
+      Puppet.debug "VShield REST API #{m} #{url} result:\n#{result.inspect}"
+      result
+    end
   end
 
-  def put(url, data)
-    result = rest[url].put Gyoku.xml(data), :content_type => 'application/xml; charset=UTF-8'
-    Puppet.debug "VShield REST put #{url} with #{data.inspect} result:\n#{result.inspect}"
-  end
-
-  def post(url, data)
-    result = rest[url].post Gyoku.xml(data), :content_type => 'application/xml; charset=UTF-8'
-    Puppet.debug "VShield REST put #{url} with #{data.inspect} result:\n#{result.inspect}"
+  [:put, :post].each do |m|
+    define_method(m) do |url, data|
+      result = rest[url].send(m, Gyoku.xml(data), :content_type => 'application/xml; charset=UTF-8')
+      Puppet.debug "VShield REST API #{m} #{url} with #{data.inspect} result:\n#{result.inspect}"
+    end
   end
 end

--- a/lib/puppet/provider/vshield_global_config/default.rb
+++ b/lib/puppet/provider/vshield_global_config/default.rb
@@ -28,13 +28,13 @@ Puppet::Type.type(:vshield_global_config).provide(:vshield_global_config, :paren
         }
       }
 
-      post('global/config', data)
+      post('api/2.0/global/config', data)
     end
   end
 
   private
 
   def config
-    @config ||= get('global/config')['vsmGlobalConfig']
+    @config ||= get('api/2.0/global/config')['vsmGlobalConfig']
   end
 end

--- a/lib/puppet/provider/vshield_syslog/default.rb
+++ b/lib/puppet/provider/vshield_syslog/default.rb
@@ -4,13 +4,13 @@ Puppet::Type.type(:vshield_syslog).provide(:vs_syslog, :parent => Puppet::Provid
   @doc = 'Manages vShield hosts syslog configuration.'
 
   def server_info
-    result = get('services/syslog/config')
+    result = get('api/2.0/services/syslog/config')
     result['syslogServerConfig']['serverInfo']
   end
 
   def server_info=(value)
     setting = { 'syslogServerConfig' =>
                 { 'serverInfo' => value } }
-    put('services/syslog/config', setting)
+    put('api/2.0/services/syslog/config', setting)
   end
 end

--- a/lib/puppet_x/puppetlabs/transport/vshield.rb
+++ b/lib/puppet_x/puppetlabs/transport/vshield.rb
@@ -14,7 +14,7 @@ module PuppetX::Puppetlabs::Transport
     end
 
     def connect
-      @rest ||= RestClient::Resource.new("https://#{@host}/api/2.0", :user => @user, :password => @password)
+      @rest ||= RestClient::Resource.new("https://#{@host}/", :user => @user, :password => @password)
     end
 
   end


### PR DESCRIPTION
The original assumption that all vShield calls are 2.0 is wrong. This
removes this faulty assumption. This also adds a few other REST
requests.
