### PR TITLE
Change transport retrieval to support multiple connection.

### DIFF
--- a/lib/puppet/provider/vcenter.rb
+++ b/lib/puppet/provider/vcenter.rb
@@ -8,7 +8,7 @@ class Puppet::Provider::Vcenter <  Puppet::Provider
   private
 
   def vim
-    @transport ||= PuppetX::Puppetlabs::Transport.retrieve(resource[:transport], resource.catalog, 'vsphere')
+    @transport ||= PuppetX::Puppetlabs::Transport.retrieve(:resource_ref => resource[:transport], :catalog => resource.catalog, :provider => 'vsphere')
     @transport.vim
   end
 

--- a/lib/puppet/provider/vcsa.rb
+++ b/lib/puppet/provider/vcsa.rb
@@ -4,7 +4,7 @@ require 'lib/puppet_x/puppetlabs/transport/ssh'
 class Puppet::Provider::Vcsa <  Puppet::Provider
 
   def self.transport(resource)
-    @transport ||= PuppetX::Puppetlabs::Transport.retrieve(resource[:transport], resource.catalog, 'ssh')
+    @transport ||= PuppetX::Puppetlabs::Transport.retrieve(:resource_ref => resource[:transport], :catalog => resource.catalog, :provider => 'ssh')
   end
 
   def transport

--- a/lib/puppet/provider/vshield.rb
+++ b/lib/puppet/provider/vshield.rb
@@ -14,7 +14,7 @@ class Puppet::Provider::Vshield <  Puppet::Provider
   private
 
   def rest
-    @transport ||= PuppetX::Puppetlabs::Transport.retrieve(resource[:transport], resource.catalog, 'vshield')
+    @transport ||= PuppetX::Puppetlabs::Transport.retrieve(:resource_ref => resource[:transport], :catalog => resource.catalog, :provider => 'vshield')
     @transport.rest
   end
 
@@ -32,5 +32,23 @@ class Puppet::Provider::Vshield <  Puppet::Provider
   def post(url, data)
     result = rest[url].post Gyoku.xml(data), :content_type => 'application/xml; charset=UTF-8'
     Puppet.debug "VShield REST put #{url} with #{data.inspect} result:\n#{result.inspect}"
+  end
+
+  # We need the corresponding vCenter connection once vShield is connected
+  def vim
+    @vsphere_transport ||= PuppetX::Puppetlabs::Transport.retrieve(:resource_hash => connection, :provider => 'vsphere')
+    @vsphere_transport.vim
+  end
+
+  def connection
+    server = vc_info['ipAddress']
+    raise Puppet::Error "vSphere API connection failure: vShield #{resource[:transport]} not connected to vCenter." unless server
+    connection = resource.catalog.resources.find{|x| x.class == Puppet::Type::Transport && x[:server] == server}.to_hash
+    raise Puppet::Error "vSphere API connection failure: vCenter #{ip_address} connection not available in manifest." unless connection
+    connection
+  end
+
+  def vc_info
+    @vc_info ||= get('api/2.0/global/config')['vsmGlobalConfig']['vcInfo']
   end
 end

--- a/lib/puppet_x/puppetlabs/transport.rb
+++ b/lib/puppet_x/puppetlabs/transport.rb
@@ -4,12 +4,18 @@ module PuppetX
       @@instances = []
 
       # Accepts a puppet resource reference, resource catalog, and loads connetivity info.
-      def self.retrieve(resource, catalog, provider)
-        name = Puppet::Resource.new(nil, resource.to_s).title
-        options = catalog.resource(resource.to_s).to_hash
+      def self.retrieve(options={})
+        unless res_hash = options[:resource_hash]
+          catalog = options[:catalog]
+          res_ref = options[:resource_ref].to_s
+          name = Puppet::Resource.new(nil, res_ref).title
+          res_hash = catalog.resource(res_ref).to_hash
+        end
+
+        provider = options[:provider]
 
         unless transport = find(name, provider)
-          transport = PuppetX::Puppetlabs::Transport::const_get(provider.capitalize).new(options)
+          transport = PuppetX::Puppetlabs::Transport::const_get(provider.capitalize).new(res_hash)
           transport.connect
           @@instances << transport
         end


### PR DESCRIPTION
Originally it was intended for one transport per resource, but for
vShield we need multiple transport per resource and the ability to
discover the vShield associated vCenter system without the user
specifying the connection. This update allows discovery of the
associated vCenter system through vShield API calls, but use the
connection info from the manifest (since it's not available in vShield).
