### PR TITLE
Fix vShield syslog when current setting nil.

### DIFF
--- a/lib/puppet/provider/vshield_syslog/default.rb
+++ b/lib/puppet/provider/vshield_syslog/default.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:vshield_syslog).provide(:vs_syslog, :parent => Puppet::Provid
   @doc = 'Manages vShield hosts syslog configuration.'
 
   def server_info
-    result = get('api/2.0/services/syslog/config')
+    result = get('api/2.0/services/syslog/config') || []
     result['syslogServerConfig']['serverInfo']
   end
 


### PR DESCRIPTION
When the current vShield syslog setting is nil, we can't treat it like
an array. This fixes the problem during initial configuration.
