### PR TITLE
Update vshield syslog when current setting is nil.

### DIFF
--- a/lib/puppet/provider/vshield.rb
+++ b/lib/puppet/provider/vshield.rb
@@ -46,11 +46,23 @@ class Puppet::Provider::Vshield <  Puppet::Provider
     server = vc_info['ipAddress']
     raise Puppet::Error "vSphere API connection failure: vShield #{resource[:transport]} not connected to vCenter." unless server
     connection = resource.catalog.resources.find{|x| x.class == Puppet::Type::Transport && x[:server] == server}.to_hash
-    raise Puppet::Error "vSphere API connection failure: vCenter #{ip_address} connection not available in manifest." unless connection
+    raise Puppet::Error "vSphere API connection failure: vCenter #{server} connection not available in manifest." unless connection
     connection
   end
 
   def vc_info
     @vc_info ||= get('api/2.0/global/config')['vsmGlobalConfig']['vcInfo']
+  end
+
+  def nested_value(hash, keys, default=nil)
+    value = hash.dup
+    keys.each_with_index do |item, index|
+      unless (value.is_a? Hash) && (value.include? item)
+        default = yield hash, keys, index if block_given?
+        return default
+      end
+      value = value[item]
+    end
+    value
   end
 end

--- a/lib/puppet/provider/vshield_syslog/default.rb
+++ b/lib/puppet/provider/vshield_syslog/default.rb
@@ -4,8 +4,8 @@ Puppet::Type.type(:vshield_syslog).provide(:vs_syslog, :parent => Puppet::Provid
   @doc = 'Manages vShield hosts syslog configuration.'
 
   def server_info
-    result = get('api/2.0/services/syslog/config') || []
-    result['syslogServerConfig']['serverInfo']
+    result = get('api/2.0/services/syslog/config')
+    nested_value(result, ['syslogServerConfig', 'serverInfo'], 'not defined.')
   end
 
   def server_info=(value)


### PR DESCRIPTION
If there are no syslog configured, the current getter fails. Added two
methods to handle the initial configuration.
