### PR TITLE
correct autorequire(:vc_host) from self[:name] to self[:host] for composite  namevars

### DIFF
--- a/lib/puppet/type/esx_datastore.rb
+++ b/lib/puppet/type/esx_datastore.rb
@@ -66,6 +66,6 @@ Puppet::Type.newtype(:esx_datastore) do
 
   autorequire(:vc_host) do
     # autorequire esx host.
-    self[:name]
+    self[:host]
   end
 end

--- a/lib/puppet/type/esx_service.rb
+++ b/lib/puppet/type/esx_service.rb
@@ -43,6 +43,6 @@ Puppet::Type.newtype(:esx_service) do
 
   autorequire(:vc_host) do
     # autorequire esx host.
-    self[:name]
+    self[:host]
   end
 end


### PR DESCRIPTION
modified:   lib/puppet/type/esx_service.rb
modified:   lib/puppet/type/esx_datastore.rb
- correct autorequire from :name to :host
