### PR TITLE
nan found adding .flatten to def edge_summary

### DIFF
--- a/lib/puppet/provider/vshield_edge/default.rb
+++ b/lib/puppet/provider/vshield_edge/default.rb
@@ -96,7 +96,7 @@ Puppet::Type.type(:vshield_edge).provide(:vshield_edge, :parent => Puppet::Provi
 
   def edge_summary
     # TODO: This may exceed 256 pagesize limit.
-    @edge_summary ||= get('api/3.0/edges')['pagedEdgeList']['edgePage']['edgeSummary'].flatten
+    @edge_summary ||= [get('api/3.0/edges')['pagedEdgeList']['edgePage']['edgeSummary']].flatten
   end
 
   def edge_detail


### PR DESCRIPTION
nan found adding .flatten to @edge_summary in def edge_summary so that when only 1 entry is found , it will still treat it as an array.
