### PR TITLE
basic config (drs, evc) for esxi cluster

### DIFF
--- a/lib/puppet/provider/vc_cluster_drs/default.rb
+++ b/lib/puppet/provider/vc_cluster_drs/default.rb
@@ -1,0 +1,46 @@
+require 'lib/puppet/provider/vcenter'
+
+Puppet::Type.type(:vc_cluster_drs).provide(:vc_cluster_drs, :parent => Puppet::Provider::Vcenter) do
+  @doc = "Manages vCenter cluster's settings for DRS (Distributed Resource Scheduler). See http://pubs.vmware.com/vsphere-50/topic/com.vmware.wssdk.apiref.doc_50/vim.cluster.ConfigSpecEx.html for detailed information on properties and methods."
+
+  Puppet::Type.type(:vc_cluster_drs).properties.collect{|x| x.name}.each do |prop|
+    camel_prop = PuppetX::VMware::Util.camelize(prop, :lower).to_sym
+
+    define_method(prop) do
+      value = current[camel_prop]
+      case value
+      when TrueClass  then :true
+      when FalseClass then :false
+      else value
+      end
+    end
+
+    define_method("#{prop}=") do |value|
+      should[camel_prop] = value
+    end
+  end
+
+  def flush
+      Puppet.debug "should is #{should.class} '#{should.inspect}'"
+      task = cluster.ReconfigureComputeResource_Task(
+          :modify => true, 
+          :spec => RbVmomi::VIM.ClusterConfigSpecEx(
+              :drsConfig => RbVmomi::VIM.ClusterDrsConfigInfo(should)
+          )
+      ).wait_for_completion
+  end
+
+  private
+
+  def should
+    @should ||= {}
+  end
+
+  def current
+    @current ||= cluster.configurationEx.drsConfig
+  end
+
+  def cluster
+    @cluster ||= locate(@resource[:path], RbVmomi::VIM::ClusterComputeResource)
+  end
+end

--- a/lib/puppet/provider/vc_cluster_evc/default.rb
+++ b/lib/puppet/provider/vc_cluster_evc/default.rb
@@ -1,0 +1,30 @@
+require 'lib/puppet/provider/vcenter'
+
+Puppet::Type.type(:vc_cluster_evc).provide(:vc_cluster_evc, :parent => Puppet::Provider::Vcenter) do
+  @doc = "Manages vCenter cluster's settings for EVC (Enhanced Vmotion Compatibility)."
+
+  def evc_mode_key
+    (cluster.summary.currentEVCModeKey || 'disabled').to_sym
+  end
+
+  def evc_mode_key=(value)
+    message = "You must use vCenter client to set EVCMode. " +
+        "This software supports verifying a cluster's EVC Mode Key but cannot set it."
+    sem = supported_evc_mode_keys
+    unless sem.dup.push(:disabled).include? value
+      Puppet.warning "Unsupported EVC Mode Key: '#{value}'"
+      Puppet.warning "Supported EVC Mode Keys are 'disabled' and cluster-specific values #{sem.map{|key| key.to_s}.inspect}."
+    end
+    fail message
+  end
+
+  private
+
+  def supported_evc_mode_keys
+    @keys ||= vim.serviceInstance.capability.supportedEVCMode.map{|evc_mode| evc_mode.key.to_sym}
+  end
+
+  def cluster
+    @cluster ||= locate(@resource[:path], RbVmomi::VIM::ClusterComputeResource)
+  end
+end

--- a/lib/puppet/type/vc_cluster_drs.rb
+++ b/lib/puppet/type/vc_cluster_drs.rb
@@ -1,0 +1,39 @@
+Puppet::Type.newtype(:vc_cluster_drs) do
+  @doc = "Manages vCenter cluster's settings for DRS (Distributed Resource Scheduler)."
+
+  newparam(:path, :namevar => true) do
+    desc "The path to the cluster."
+
+    validate do |value|
+      raise "Absolute path required: #{value}" unless Puppet::Util.absolute_path?(value)
+    end
+  end
+
+  newproperty(:enabled) do
+   desc "Is DRS enabled? true or false"
+   newvalues(:true, :false)
+  end
+
+  newproperty(:enable_vm_behavior_overrides) do
+   desc "Is VM-specific override of cluster-wide DRS behavior enabled? true or false"
+   newvalues(:true, :false)
+  end
+
+  newproperty(:default_vm_behavior) do
+   desc "Cluster-wide default for DRS management of VMs: fullyAutomated, partiallyAutomated, or manual"
+   newvalues(:fullyAutomated, :partiallyAutomated, :manual)
+   munge do |value| value.to_sym end
+  end
+
+  newproperty(:vmotion_rate) do
+    desc "Aggressiveness of DRS actions or recommendations for vMotion: 1 (aggressive) through 5 (conservative)"
+    newvalues(1, 2, 3, 4, 5)
+    munge do |value| value.to_i end
+  end
+
+  # autorequire cluster - cluster's path is used for its cluster configuration resources
+  autorequire(:vc_cluster) do
+    Pathname.new(self[:path]).to_s
+  end
+
+end

--- a/lib/puppet/type/vc_cluster_evc.rb
+++ b/lib/puppet/type/vc_cluster_evc.rb
@@ -1,0 +1,27 @@
+Puppet::Type.newtype(:vc_cluster_evc) do
+  @doc = "Manages vCenter cluster's settings for EVC (Enhanced Vmotion Compatibility)."
+
+  newparam(:path, :namevar => true) do
+    desc "The path to the cluster."
+
+    validate do |value|
+      raise "Absolute path required: #{value}" unless Puppet::Util.absolute_path?(value)
+    end
+  end
+
+  newproperty(:evc_mode_key) do
+    desc "A string corresponding to the desired EVC Mode; or 'disabled' to disable EVC"
+    defaultto(:disabled)
+
+    munge do |value|
+      value = value.to_sym
+    end
+
+  end
+
+  # autorequire cluster - same path used for cluster configuration resources
+  autorequire(:vc_cluster) do
+    Pathname.new(self[:path]).to_s
+  end
+
+end

--- a/lib/puppet/type/vc_host.rb
+++ b/lib/puppet/type/vc_host.rb
@@ -58,4 +58,9 @@ Puppet::Type.newtype(:vc_host) do
     # autorequire immediate parent Cluster.
     self[:path]
   end
+
+  autorequire(:anchor) do
+    # autorequire optional anchor to wait for vc_cluster config
+    self[:path]
+  end
 end

--- a/tests/vc_cluster.pp
+++ b/tests/vc_cluster.pp
@@ -1,0 +1,167 @@
+# Note on cluster anchor:
+#  anchor { '$cluster_path':
+#    require => Vc_cluster['$cluster_path'],
+#  }
+#
+# This anchor marks completion of cluster configuration,
+# which may be a multi-step or multi-run process.
+#
+# If a change in EVC is requested, manual setting of EVC is 
+# required. The EVC resource should specify 'before => Anchor[$cluster_path]'.
+#
+# Steps that require a fully configured cluster (such as hosts to
+# be added to the cluster) should specify 'require => Anchor[$cluster_path]', 
+# not 'require Vc_cluster[$cluster_path]'.
+
+transport { 'vcenter':
+  username => 'root',
+  password => 'vmware',
+  server   => 'vc0.rbbrown.dev'
+}
+vc_datacenter { 'testClusters':
+  path      => '/testClusters',
+  ensure    => present,
+  transport => Transport['vcenter'],
+}
+
+# --- cluster tc000: create cluster with default configuration
+vc_cluster { '/testClusters/tc000':
+  transport => Transport['vcenter'],
+  ensure    => present,
+}
+vc_cluster_drs { '/testClusters/tc000':
+  transport => Transport['vcenter'],
+  require => Vc_cluster['/testClusters/tc000'],
+  before => Anchor['/testClusters/tc000'],
+  #
+  # enabled => false,
+}
+vc_cluster_evc { '/testClusters/tc000':
+  transport => Transport['vcenter'],
+  require => [
+      Vc_cluster['/testClusters/tc000'],
+      Vc_cluster_drs['/testClusters/tc000'],
+    ],
+  before => Anchor['/testClusters/tc000'],
+  #
+  # evc_mode_key => 'disabled',
+}
+anchor { '/testClusters/tc000':
+  require => Vc_cluster['/testClusters/tc000'],
+  #
+  # This anchor marks completion of cluster configuration,
+  # which may be a multi-step or multi-run process.
+  #
+  # If a change in EVC is requested, manual setting of EVC is 
+  # required. The EVC resource should specify 'before => Anchor[..]'.
+  #
+  # Steps that require a fully configured cluster (such as hosts to
+  # be added to the cluster) should specify 'require => Anchor[..]', 
+  # not 'require Vc_cluster[..]'.
+  #
+}
+
+# --- cluster drs001: all basic DRS, fully on
+vc_cluster { '/testClusters/drs001':
+  transport => Transport['vcenter'],
+  ensure    => present,
+}
+vc_cluster_drs { '/testClusters/drs001':
+  transport => Transport['vcenter'],
+  require => Vc_cluster['/testClusters/drs001'],
+  before => Anchor['/testClusters/drs001'],
+  #
+  enabled => true,
+  enable_vm_behavior_overrides => true,
+  default_vm_behavior => 'fullyAutomated',
+  vmotion_rate => 1,
+}
+vc_cluster_evc { '/testClusters/drs001':
+  transport => Transport['vcenter'],
+  require => [
+      Vc_cluster['/testClusters/drs001'],
+      Vc_cluster_drs['/testClusters/drs001'],
+    ],
+  before => Anchor['/testClusters/drs001'],
+  #
+  evc_mode_key => 'disabled',
+}
+anchor { '/testClusters/drs001':
+  require => Vc_cluster['/testClusters/drs001'],
+}
+
+# --- cluster evc001: invalid evc mode - check for supported list, including 'disabled'
+vc_cluster { '/testClusters/evc001':
+  transport => Transport['vcenter'],
+  ensure    => present,
+}
+vc_cluster_drs { '/testClusters/evc001':
+  transport => Transport['vcenter'],
+  require => Vc_cluster['/testClusters/evc001'],
+  before => Anchor['/testClusters/evc001'],
+  #
+  enabled => true,
+}
+vc_cluster_evc { '/testClusters/evc001':
+  transport => Transport['vcenter'],
+  require => [
+      Vc_cluster['/testClusters/evc001'],
+      Vc_cluster_drs['/testClusters/evc001'],
+    ],
+  before => Anchor['/testClusters/evc001'],
+  #
+  evc_mode_key => 'disabledX',
+}
+anchor { '/testClusters/evc001':
+  require => Vc_cluster['/testClusters/evc001'],
+}
+
+# --- cluster evc002: evc mode 'disabled' - rerun after enabling EVC Mode, check for failure
+vc_cluster { '/testClusters/evc002':
+  transport => Transport['vcenter'],
+  ensure    => present,
+}
+vc_cluster_drs { '/testClusters/evc002':
+  transport => Transport['vcenter'],
+  require => Vc_cluster['/testClusters/evc002'],
+  before => Anchor['/testClusters/evc002'],
+  #
+}
+vc_cluster_evc { '/testClusters/evc002':
+  transport => Transport['vcenter'],
+  require => [
+      Vc_cluster['/testClusters/evc002'],
+      Vc_cluster_drs['/testClusters/evc002'],
+    ],
+  before => Anchor['/testClusters/evc002'],
+  #
+  evc_mode_key => 'disabled',
+}
+anchor { '/testClusters/evc002':
+  require => Vc_cluster['/testClusters/evc002'],
+}
+
+# --- cluster evc003: evc mode 'intel-westmere'; rerun after setting EVC to match, check for success
+vc_cluster { '/testClusters/evc003':
+  transport => Transport['vcenter'],
+  ensure    => present,
+}
+vc_cluster_drs { '/testClusters/evc003':
+  transport => Transport['vcenter'],
+  require => Vc_cluster['/testClusters/evc003'],
+  before => Anchor['/testClusters/evc003'],
+  #
+}
+vc_cluster_evc { '/testClusters/evc003':
+  transport => Transport['vcenter'],
+  require => [
+      Vc_cluster['/testClusters/evc003'],
+      Vc_cluster_drs['/testClusters/evc003'],
+    ],
+  before => Anchor['/testClusters/evc003'],
+  #
+  evc_mode_key => 'intel-westmere',
+}
+anchor { '/testClusters/evc003':
+  require => Vc_cluster['/testClusters/evc003'],
+}

--- a/tests/vc_cluster_wipe.pp
+++ b/tests/vc_cluster_wipe.pp
@@ -1,0 +1,22 @@
+transport { 'vcenter':
+  username => 'root',
+  password => 'vmware',
+  server   => 'vc0.rbbrown.dev'
+}
+vc_datacenter { 'testClusters':
+  path      => '/testClusters',
+  ensure    => present,
+  transport => Transport['vcenter'],
+}
+
+vc_cluster { '/testClusters/tc000': transport => Transport['vcenter'], ensure    => absent, }
+
+vc_cluster { '/testClusters/drs001': transport => Transport['vcenter'], ensure    => absent, }
+vc_cluster { '/testClusters/drs002': transport => Transport['vcenter'], ensure    => absent, }
+vc_cluster { '/testClusters/drs003': transport => Transport['vcenter'], ensure    => absent, }
+vc_cluster { '/testClusters/drs004': transport => Transport['vcenter'], ensure    => absent, }
+
+vc_cluster { '/testClusters/evc001': transport => Transport['vcenter'], ensure    => absent, }
+vc_cluster { '/testClusters/evc002': transport => Transport['vcenter'], ensure    => absent, }
+vc_cluster { '/testClusters/evc003': transport => Transport['vcenter'], ensure    => absent, }
+vc_cluster { '/testClusters/evc004': transport => Transport['vcenter'], ensure    => absent, }


### PR DESCRIPTION
To get basic cluster config available. Simple DRS + EVC Mode check. No HA yet. 

new file:   lib/puppet/provider/vc_cluster_drs/default.rb
new file:   lib/puppet/provider/vc_cluster_evc/default.rb
new file:   lib/puppet/type/vc_cluster_drs.rb
new file:   lib/puppet/type/vc_cluster_evc.rb
modified:   lib/puppet/type/vc_host.rb
- set cluster's basic drs propertie
- check cluster's evc_mode - fail if not as expected
- add autorequire to vc_host - anchor[:path] to allow host
  to wait for correct evc_mode (or other cluster configuration)
