### PR TITLE
autorequire datastore if log_dir is specified for esx_syslog

### DIFF
--- a/lib/puppet/type/esx_syslog.rb
+++ b/lib/puppet/type/esx_syslog.rb
@@ -44,4 +44,12 @@ Puppet::Type.newtype(:esx_syslog) do
     # autorequire esx host.
     self[:name]
   end
+
+  autorequire(:esx_datastore) do
+    # autorequire datastore from log_dir
+    if self[:log_dir]
+      ds = self[:log_dir].match(/\[([^\]]+)\](.*)/)[1]
+      "#{self[:name]}:#{ds}"
+    end
+  end
 end


### PR DESCRIPTION
modified:   lib/puppet/type/esx_syslog.rb
- autorequire datastore if log_dir is specified
