### PR TITLE
Improve vshield connection error message.

### DIFF
--- a/lib/puppet/provider/vshield.rb
+++ b/lib/puppet/provider/vshield.rb
@@ -44,10 +44,10 @@ class Puppet::Provider::Vshield <  Puppet::Provider
 
   def connection
     server = vc_info['ipAddress']
-    raise Puppet::Error "vSphere API connection failure: vShield #{resource[:transport]} not connected to vCenter." unless server
-    connection = resource.catalog.resources.find{|x| x.class == Puppet::Type::Transport && x[:server] == server}.to_hash
-    raise Puppet::Error "vSphere API connection failure: vCenter #{server} connection not available in manifest." unless connection
-    connection
+    raise Puppet::Error, "vSphere API connection failure: vShield #{resource[:transport]} not connected to vCenter." unless server
+    connection = resource.catalog.resources.find{|x| x.class == Puppet::Type::Transport && x[:server] == server}
+    raise Puppet::Error, "vSphere API connection failure: vCenter #{server} transport connection not available in manifest." unless connection
+    connection.to_hash
   end
 
   def vc_info


### PR DESCRIPTION
Originally the error message was: undefined method `to_hash' for
nil:NilClass, now the error message is: vSphere API connection failure:
vCenter #{ip_address} connection not available in manifest.
