### PR TITLE
Improve RestClient Error messages.

### DIFF
--- a/lib/puppet/provider/vshield.rb
+++ b/lib/puppet/provider/vshield.rb
@@ -23,7 +23,11 @@ class Puppet::Provider::Vshield <  Puppet::Provider
 
   [:get, :delete].each do |m|
     define_method(m) do |url|
-      result = Nori.parse(rest[url].send(m))
+      begin
+        result = Nori.parse(rest[url].send(m))
+      rescue RestClient::Exception => e
+        raise Puppet::Error, "\n#{e.exception}:\n#{e.response}"
+      end
       Puppet.debug "VShield REST API #{m} #{url} result:\n#{result.inspect}"
       result
     end
@@ -31,7 +35,11 @@ class Puppet::Provider::Vshield <  Puppet::Provider
 
   [:put, :post].each do |m|
     define_method(m) do |url, data|
-      result = rest[url].send(m, Gyoku.xml(data), :content_type => 'application/xml; charset=UTF-8')
+      begin
+        result = rest[url].send(m, Gyoku.xml(data), :content_type => 'application/xml; charset=UTF-8')
+      rescue RestClient::Exception => e
+        raise Puppet::Error, "\n#{e.exception}:\n#{e.response}"
+      end
       Puppet.debug "VShield REST API #{m} #{url} with #{data.inspect} result:\n#{result.inspect}"
     end
   end


### PR DESCRIPTION
Instead of just providing error code, this update gives more error
details.

Before: "400 Bad Request"
After: (Not formatted)

```
400 Bad Request:
<error>
<details>Not licensed for Entity : vshield-edge feature :  : add
on :
</details>
<errorCode>214</errorCode>
<moduleName>core-services</moduleName>
</error>
```
