### PR TITLE
esx_syslog: fixup 'is_now' for boolean

### DIFF
--- a/lib/puppet/provider/esx_syslog/default.rb
+++ b/lib/puppet/provider/esx_syslog/default.rb
@@ -14,7 +14,10 @@ Puppet::Type.type(:esx_syslog).provide(:esx_syslog, :parent => Puppet::Provider:
     camel_prop = PuppetX::VMware::Util.camelize(prop, :lower).to_sym
 
     define_method(prop) do
-      config[camel_prop]
+      v = config[camel_prop]
+      v = :false if FalseClass === v
+      v = :true  if TrueClass  === v
+      v
     end
 
     define_method("#{prop}=") do |value|


### PR DESCRIPTION
Prevent stupid messages (and changes) like
    /Stage[main]//Esx_syslog[esx4.rbbrown.dev]/log_dir_unique: 
              log_dir_unique changed 'true' to 'true'
