### PR TITLE
Pin nori to version 1.1.3.

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -4,10 +4,15 @@ class vcenter::package (
     'hashdiff',
     'rest-client',
     'rbvmomi',
-    'nori',
     'gyoku',
   ]:
     ensure   => present,
+    provider => $::vcenter::params::provider,
+  }
+
+  # nori 2.0.0 gem is not compatible with PE (nokogiri?)
+  package { 'nori':
+    ensure   => '1.1.3',
     provider => $::vcenter::params::provider,
   }
 }


### PR DESCRIPTION
Later versions of Nori is not compatible with PE at the moment.
