### PR TITLE
Update test to be more portable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ rdoc
 spec/reports
 test/tmp
 test/version_tmp
+tests/data.yaml
 tmp
 
 # YARD artifacts

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,6 @@
+# Testing with data.yaml
+
+Since each environment is different, we want to keep a set of test manifests that is easy to share. The goal is to keep the manifests generic so it doesn't require changes for testing. Copy the sample.yaml into data.yaml and modify it to suit your lab environment.
+
+    $ cp sample.yaml data.yaml
+    $ enc_apply --noop vcsa.pp

--- a/tests/enc.sh
+++ b/tests/enc.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+require 'pathname'
+dir = Pathname.new(__FILE__).parent
+
+begin
+  f = File.new(File.join(dir, 'data.yaml'), 'r')
+  puts f.read
+ensure
+  f.close
+end

--- a/tests/enc_apply
+++ b/tests/enc_apply
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -u
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+puppet apply --node_terminus=exec --external_nodes="${DIR}/enc.sh" "$@"

--- a/tests/esx_datastore.pp
+++ b/tests/esx_datastore.pp
@@ -1,13 +1,13 @@
 transport { 'vcenter':
-  username => 'root',
-  password => 'vmware',
-  server   => '192.168.232.147',
+  username => $vcsa_user,
+  password => $vcsa_pass,
+  server   => $vcsa_ip,
 }
 
-esx_datastore { '192.168.232.240:nfs_store':
+esx_datastore { "${esx_ip}:nfs_store":
   ensure      => present,
   type        => 'nfs',
-  remote_host => '192.168.232.1',
-  remote_path => '/Users/nan/src/nodejs',
+  remote_host => $nfs_host,
+  remote_path => $nfs_mount,
   transport   => Transport['vcenter'],
 }

--- a/tests/esx_debug.pp
+++ b/tests/esx_debug.pp
@@ -1,10 +1,10 @@
 transport { 'vcenter':
-  username => 'root',
-  password => 'vmware',
-  server   => '192.168.232.147',
+  username => $vcsa_user,
+  password => $vcsa_pass,
+  server   => $vcsa_ip,
 }
 
-esx_debug { '192.168.232.240':
+esx_debug { $esx_ip:
   debug     => true,
   transport => Transport['vcenter'],
 }

--- a/tests/esx_ntpconfig.pp
+++ b/tests/esx_ntpconfig.pp
@@ -1,10 +1,10 @@
 transport { 'vcenter':
-  username => 'root',
-  password => 'vmware',
-  server   => '192.168.232.147',
+  username => $vcsa_user,
+  password => $vcsa_pass,
+  server   => $vcsa_ip,
 }
 
-esx_ntpconfig { '192.168.232.240':
-  server    => ['ntp.puppetlabs.com','ntp.puppetlabs.lan'],
+esx_ntpconfig { $esx_ip:
+  server    => $esx_ntp_server,
   transport => Transport['vcenter'],
 }

--- a/tests/esx_service.pp
+++ b/tests/esx_service.pp
@@ -1,12 +1,12 @@
 transport { 'vcenter':
-  username => 'root',
-  password => 'vmware',
-  server   => '192.168.232.147',
+  username => $vcsa_user,
+  password => $vcsa_pass,
+  server   => $vcsa_ip,
 }
 
 notify { 'trigger': }
 
-esx_service { '192.168.232.240:ntpd':
+esx_service { "${esx_ip}:ntpd":
   running   => false,
   policy    => 'on',
   transport => Transport['vcenter'],

--- a/tests/esx_syslog.pp
+++ b/tests/esx_syslog.pp
@@ -1,10 +1,10 @@
 transport { 'vcenter':
-  username => 'root',
-  password => 'vmware',
-  server   => '192.168.232.147',
+  username => $vcsa_user,
+  password => $vcsa_pass,
+  server   => $vcsa_ip,
 }
 
-esx_syslog { '192.168.232.240':
+esx_syslog { $esx_ip:
   default_rotate => 8,
   default_size   => 2048,
   log_dir_unique => true,

--- a/tests/esx_timezone.pp
+++ b/tests/esx_timezone.pp
@@ -1,10 +1,10 @@
 transport { 'vcenter':
-  username => 'root',
-  password => 'vmware',
-  server   => '192.168.232.147',
+  username => $vcsa_user,
+  password => $vcsa_pass,
+  server   => $vcsa_ip,
 }
 
-esx_timezone { '192.168.232.240':
+esx_timezone { $esx_ip:
   key       => 'EST',
   transport => Transport['vcenter'],
 }

--- a/tests/example.yaml
+++ b/tests/example.yaml
@@ -1,0 +1,17 @@
+--- 
+parameters: 
+  # vCenter connectivity
+  vcsa_ip: 192.168.1.3
+  vcsa_user: root
+  vcsa_pass: vmware
+  # vShield connectivity
+  vshield_ip: 192.168.1.4
+  vshield_user: admin
+  vshield_pass: default
+  # ESX connectivity
+  esx_ip: 192.168.1.5
+  esx_user: root
+  esx_pass: vmware
+  esx_ntp_server: [ 0.north-america.pool.ntp.org, 1.north-america.pool.ntp.org ]
+  nfs_host: 192.168.1.2
+  nfs_mout: /export/nfs

--- a/tests/vc_cluster.pp
+++ b/tests/vc_cluster.pp
@@ -14,9 +14,9 @@
 # not 'require Vc_cluster[$cluster_path]'.
 
 transport { 'vcenter':
-  username => 'root',
-  password => 'vmware',
-  server   => 'vc0.rbbrown.dev'
+  username => $vcsa_user,
+  password => $vcsa_pass,
+  server   => $vcsa_ip,
 }
 vc_datacenter { 'testClusters':
   path      => '/testClusters',

--- a/tests/vc_cluster_wipe.pp
+++ b/tests/vc_cluster_wipe.pp
@@ -1,7 +1,7 @@
 transport { 'vcenter':
-  username => 'root',
-  password => 'vmware',
-  server   => 'vc0.rbbrown.dev'
+  username => $vcsa_user,
+  password => $vcsa_pass,
+  server   => $vcsa_ip,
 }
 vc_datacenter { 'testClusters':
   path      => '/testClusters',

--- a/tests/vc_datacenter.pp
+++ b/tests/vc_datacenter.pp
@@ -1,7 +1,7 @@
 transport { 'vcenter':
-  username => 'root',
-  password => 'vmware',
-  server   => '192.168.232.147',
+  username => $vcsa_user,
+  password => $vcsa_pass,
+  server   => $vcsa_ip,
 }
 
 vc_datacenter { 'dc1':

--- a/tests/vc_folder.pp
+++ b/tests/vc_folder.pp
@@ -1,7 +1,7 @@
 transport { 'vcenter':
-  username => 'root',
-  password => 'vmware',
-  server   => '192.168.232.147',
+  username => $vcsa_user,
+  password => $vcsa_pass,
+  server   => $vcsa_ip,
 }
 
 vc_folder { ['/folder1','/folder1/a','/folder1/a/b']:

--- a/tests/vc_host.pp
+++ b/tests/vc_host.pp
@@ -1,7 +1,7 @@
 transport { 'vcenter':
-  username => 'root',
-  password => 'vmware',
-  server   => '192.168.232.147',
+  username => $vcsa_user,
+  password => $vcsa_pass,
+  server   => $vcsa_ip,
 }
 
 vc_datacenter { 'dc1':

--- a/tests/vc_vm.pp
+++ b/tests/vc_vm.pp
@@ -1,7 +1,7 @@
 transport { 'vcenter':
-  username => 'root',
-  password => 'vmware',
-  server   => '192.168.232.147',
+  username => $vcsa_user,
+  password => $vcsa_pass,
+  server   => $vcsa_ip,
 }
 
 vc_vm { 'test2':

--- a/tests/vcsa.pp
+++ b/tests/vcsa.pp
@@ -1,5 +1,7 @@
 vcenter::vcsa { 'demo':
-  server   => '192.168.232.147',
+  username => $vcsa_user,
+  password => $vcsa_pass,
+  server   => $vcsa_ip,
   db_type  => 'embedded',
   capacity => 'm',
 }

--- a/tests/vcsa_db.pp
+++ b/tests/vcsa_db.pp
@@ -1,7 +1,7 @@
 transport { 'demo':
-  username => 'root',
-  password => 'vmware',
-  server   => '192.168.101.157',
+  username => $vcsa_user,
+  password => $vcsa_pass,
+  server   => $vcsa_ip,
 }
 
 vcsa_db { 'demo':

--- a/tests/vcsa_eula.pp
+++ b/tests/vcsa_eula.pp
@@ -1,7 +1,7 @@
 transport { 'demo':
-  username => 'root',
-  password => 'vmware',
-  server   => '192.168.101.157',
+  username => $vcsa_user,
+  password => $vcsa_pass,
+  server   => $vcsa_ip,
 }
 
 vcsa_eula { 'demo':


### PR DESCRIPTION
The current test manifests require manual changes for different
environments. This change aims to make the tests manifests more generic
so a custom data.yaml file captures the differences between labs.
