### PR TITLE
No longer use hard coded insecure connection.

### DIFF
--- a/lib/puppet_x/puppetlabs/transport/vsphere.rb
+++ b/lib/puppet_x/puppetlabs/transport/vsphere.rb
@@ -3,18 +3,18 @@ require 'rbvmomi' if Puppet.features.vsphere? and ! Puppet.run_mode.master?
 module PuppetX::Puppetlabs::Transport
   class Vsphere
     attr_accessor :vim
-    attr_reader :name, :user, :password, :host
 
-    def initialize(option)
-      @name     = option[:name]
-      @user     = option[:username]
-      @password = option[:password]
-      @host     = option[:server]
+    def initialize(opts)
+      options  = opts[:options] || {}
+      @options = options.inject({}){|h, (k, v)| h[k.to_sym] = v; h}
+      @options[:host]     = opts[:server]
+      @options[:user]     = opts[:username]
+      @options[:password] = opts[:password]
       Puppet.debug("#{self.class} initializing connection to: #{@host}")
     end
 
     def connect
-      @vim ||= RbVmomi::VIM.connect(:host => @host, :user => @user, :password => @password, :insecure => true)
+      @vim ||= RbVmomi::VIM.connect(@options)
     end
 
     def close


### PR DESCRIPTION
Since we support transport options. Allow users to specify rbvmomi 
connectivity options such as :insecure instead of hard coding it in the 
transport.
