### PR TITLE
Revert removal of transport name.

### DIFF
--- a/lib/puppet_x/puppetlabs/transport/vsphere.rb
+++ b/lib/puppet_x/puppetlabs/transport/vsphere.rb
@@ -4,8 +4,10 @@ require 'rbvmomi' if Puppet.features.vsphere? and ! Puppet.run_mode.master?
 module PuppetX::Puppetlabs::Transport
   class Vsphere
     attr_accessor :vim
+    attr_reader :name
 
     def initialize(opts)
+      @name    = opts[:name]
       options  = opts[:options] || {}
       @options = options.inject({}){|h, (k, v)| h[k.to_sym] = v; h}
       @options[:host]     = opts[:server]


### PR DESCRIPTION
We stil need transport attr_reader name to find the resources.
