### PR TITLE
simplify use and extension of PuppetX::VMware::Mapper

### DIFF
--- a/lib/puppet/provider/vc_cluster_ha/default.rb
+++ b/lib/puppet/provider/vc_cluster_ha/default.rb
@@ -12,7 +12,7 @@ require File.join module_lib, 'puppet_x/vmware/mapper'
 Puppet::Type.type(:vc_cluster_ha).provide(:vc_cluster_ha, :parent => Puppet::Provider::Vcenter) do
   @doc = "Manages vCenter cluster's settings for HA (High Availability)."
 
-  clusterConfigSpecExMap ||= PuppetX::VMware::Mapper::ClusterConfigSpecExMap.new
+  clusterConfigSpecExMap ||= PuppetX::VMware::Mapper.new_map('ClusterConfigSpecExMap')
 
   clusterConfigSpecExMap.leaf_list.each do |leaf|
     define_method(leaf.prop_name) do

--- a/lib/puppet/type/vc_cluster_ha.rb
+++ b/lib/puppet/type/vc_cluster_ha.rb
@@ -19,7 +19,7 @@ Puppet::Type.newtype(:vc_cluster_ha) do
     end
   end
 
-  clusterConfigSpecExMap = PuppetX::VMware::Mapper::ClusterConfigSpecExMap.new
+  clusterConfigSpecExMap = PuppetX::VMware::Mapper.new_map('ClusterConfigSpecExMap')
   clusterConfigSpecExMap.leaf_list.each do |leaf|
     if leaf.misc.include?(Array)
       option = {

--- a/lib/puppet_x/vmware/mapper.rb
+++ b/lib/puppet_x/vmware/mapper.rb
@@ -1,7 +1,25 @@
 # Copyright (C) 2013 VMware, Inc.
+require 'pathname' # WORK_AROUND #14073 and #7788
+
+vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
+require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
+
+module_lib = Pathname.new(__FILE__).parent.parent.parent
+
 module PuppetX
   module VMware
     module Mapper
+
+      def self.new_map mapname
+        mapfile = PuppetX::VMware::Util.snakeize mapname
+        require 'pathname'
+        file_path = Pathname.new(__FILE__)
+        Puppet.debug "require \"#{file_path.parent}/#{file_path.basename '.rb'}/#{mapfile}\""
+        require "#{file_path.parent}/#{file_path.basename '.rb'}/#{mapfile}"
+        PuppetX::VMware::Mapper::const_get(mapname).new
+      rescue Exception => e
+        fail "#{self.name}: Error accessing or creating mapper \"#{mapname}\": #{e.message}"
+      end
 
       class MapComponent
 
@@ -256,127 +274,6 @@ module PuppetX
               node_list.push(Node.new value)
             end
           end
-        end
-      end
-
-      class ClusterConfigSpecExMap < Map
-        def initialize
-          @initTree = {
-            Node => NodeData[
-              :node_type => 'ClusterConfigSpecEx',
-            ],
-            :dasConfig => {
-              Node => NodeData[
-                :node_type => 'ClusterDasConfigInfo',
-              ],
-              :enabled => LeafData[
-                :prop_name => :das_config_enabled,
-                :desc => "Is HA enabled? true or false",
-                :valid_enum => [:true, :false],
-              ],
-              :admissionControlEnabled => LeafData[
-                :desc => "Is admission control enabled? true or false",
-                :valid_enum => [:true, :false],
-              ],
-              :admissionControlPolicy => {
-                Node => NodeData[
-                  :node_type => :ABSTRACT
-                ],
-                :vsphereType => LeafData[
-                  :prop_name => :admission_control_policy_type,
-                  :valid_enum => [
-                    :ClusterFailoverHostAdmissionControlPolicy,
-                    :ClusterFailoverLevelAdmissionControlPolicy,
-                    :ClusterFailoverResourcesAdmissionControlPolicy,
-                  ],
-                ],
-                :failoverHosts => LeafData[
-                  :misc => [Array],
-                  :requires => [:admission_control_policy_type],
-                ],
-                :failoverLevel => LeafData[
-                  :desc => \
-                    "Number of host failures that should be tolerated, "\
-                    "still guaranteeing sufficient resources to restart "\
-                    "virtual machines on available hosts. ",
-                  :validate => PuppetX::VMware::Mapper::validate_i_ge(0),
-                  :munge => PuppetX::VMware::Mapper::munge_to_i,
-                  :requires => [:admission_control_policy_type],
-                ],
-                :cpuFailoverResourcesPercent => LeafData[
-                  :valid_enum => 1..100,
-                  :munge => PuppetX::VMware::Mapper::munge_to_i,
-                  :requires => [:admission_control_policy_type, :memory_failover_resources_percent],
-                ],
-                :memoryFailoverResourcesPercent => LeafData[
-                  :valid_enum => 1..100,
-                  :munge => PuppetX::VMware::Mapper::munge_to_i,
-                  :requires => [:admission_control_policy_type, :cpu_failover_resources_percent],
-                ],
-              },
-              :defaultVmSettings => {
-                Node => NodeData[
-                  :node_type => 'ClusterDasVmSettings',
-                ],
-                :isolationResponse => LeafData[
-                  :desc => \
-                    "isolation response when a virtual machine has no "\
-                    "HA configuration of its own (ClusterDasVmConfigSpec). ",
-                  :valid_enum => [:none, :powerOff, :shutdown,],
-                ],
-                :restartPriority => LeafData[
-                  :desc => \
-                    "restart priority when a virtual machine has no HA "\
-                    "configuration of its own (ClusterDasVmConfigSpec). ",
-                  :valid_enum => [:disabled, :high, :low, :medium,],
-                ],
-                :vmToolsMonitoringSettings => {
-                  Node => NodeData[
-                    :node_type => 'ClusterVmToolsMonitoringSettings',
-                  ],
-                  :failureInterval => LeafData[
-                    :validate => PuppetX::VMware::Mapper::validate_i_ge(1),
-                    :munge => PuppetX::VMware::Mapper::munge_to_i,
-                  ],
-                  :maxFailures => LeafData[
-                    :validate => PuppetX::VMware::Mapper::validate_i_ge(-1),
-                    :munge => PuppetX::VMware::Mapper::munge_to_i,
-                  ],
-                  :maxFailureWindow => LeafData[
-                    :validate => PuppetX::VMware::Mapper::validate_i_ge(-1),
-                    :munge => PuppetX::VMware::Mapper::munge_to_i,
-                  ],
-                  :minUpTime => LeafData[
-                    :validate => PuppetX::VMware::Mapper::validate_i_ge(1),
-                    :munge => PuppetX::VMware::Mapper::munge_to_i,
-                  ],
-                  :vmMonitoring => LeafData[
-                    :munge => PuppetX::VMware::Mapper::munge_to_sym,
-                    :valid_enum => [
-                        :vmMonitoringDisabled,
-                        :vmMonitoringOnly,
-                        :vmAndAppMonitoring,
-                    ],
-                  ],
-                },
-              },
-              :hostMonitoring => LeafData[
-                  :desc => "Is host monitoring enabled? enabled or disabled",
-                  :valid_enum => [:enabled, :disabled],
-              ],
-              :vmMonitoring => LeafData[
-                :prop_name => :das_config_vm_monitoring,
-                :munge => PuppetX::VMware::Mapper::munge_to_sym,
-                :valid_enum => [
-                    :vmMonitoringDisabled,
-                    :vmMonitoringOnly,
-                    :vmAndAppMonitoring,
-                ],
-              ],
-            },
-          }
-
-          super
         end
       end
 

--- a/lib/puppet_x/vmware/mapper/cluster_config_spec_ex_map.rb
+++ b/lib/puppet_x/vmware/mapper/cluster_config_spec_ex_map.rb
@@ -1,0 +1,125 @@
+# Copyright (C) 2013 VMware, Inc.
+module PuppetX::VMware::Mapper
+
+  class ClusterConfigSpecExMap < Map
+    def initialize
+      @initTree = {
+        Node => NodeData[
+          :node_type => 'ClusterConfigSpecEx',
+        ],
+        :dasConfig => {
+          Node => NodeData[
+            :node_type => 'ClusterDasConfigInfo',
+          ],
+          :enabled => LeafData[
+            :prop_name => :das_config_enabled,
+            :desc => "Is HA enabled? true or false",
+            :valid_enum => [:true, :false],
+          ],
+          :admissionControlEnabled => LeafData[
+            :desc => "Is admission control enabled? true or false",
+            :valid_enum => [:true, :false],
+          ],
+          :admissionControlPolicy => {
+            Node => NodeData[
+              :node_type => :ABSTRACT
+            ],
+            :vsphereType => LeafData[
+              :prop_name => :admission_control_policy_type,
+              :valid_enum => [
+                :ClusterFailoverHostAdmissionControlPolicy,
+                :ClusterFailoverLevelAdmissionControlPolicy,
+                :ClusterFailoverResourcesAdmissionControlPolicy,
+              ],
+            ],
+            :failoverHosts => LeafData[
+              :misc => [Array],
+              :requires => [:admission_control_policy_type],
+            ],
+            :failoverLevel => LeafData[
+              :desc => \
+                "Number of host failures that should be tolerated, "\
+                "still guaranteeing sufficient resources to restart "\
+                "virtual machines on available hosts. ",
+              :validate => PuppetX::VMware::Mapper::validate_i_ge(0),
+              :munge => PuppetX::VMware::Mapper::munge_to_i,
+              :requires => [:admission_control_policy_type],
+            ],
+            :cpuFailoverResourcesPercent => LeafData[
+              :valid_enum => 1..100,
+              :munge => PuppetX::VMware::Mapper::munge_to_i,
+              :requires => [:admission_control_policy_type, :memory_failover_resources_percent],
+            ],
+            :memoryFailoverResourcesPercent => LeafData[
+              :valid_enum => 1..100,
+              :munge => PuppetX::VMware::Mapper::munge_to_i,
+              :requires => [:admission_control_policy_type, :cpu_failover_resources_percent],
+            ],
+          },
+          :defaultVmSettings => {
+            Node => NodeData[
+              :node_type => 'ClusterDasVmSettings',
+            ],
+            :isolationResponse => LeafData[
+              :desc => \
+                "isolation response when a virtual machine has no "\
+                "HA configuration of its own (ClusterDasVmConfigSpec). ",
+              :valid_enum => [:none, :powerOff, :shutdown,],
+            ],
+            :restartPriority => LeafData[
+              :desc => \
+                "restart priority when a virtual machine has no HA "\
+                "configuration of its own (ClusterDasVmConfigSpec). ",
+              :valid_enum => [:disabled, :high, :low, :medium,],
+            ],
+            :vmToolsMonitoringSettings => {
+              Node => NodeData[
+                :node_type => 'ClusterVmToolsMonitoringSettings',
+              ],
+              :failureInterval => LeafData[
+                :validate => PuppetX::VMware::Mapper::validate_i_ge(1),
+                :munge => PuppetX::VMware::Mapper::munge_to_i,
+              ],
+              :maxFailures => LeafData[
+                :validate => PuppetX::VMware::Mapper::validate_i_ge(-1),
+                :munge => PuppetX::VMware::Mapper::munge_to_i,
+              ],
+              :maxFailureWindow => LeafData[
+                :validate => PuppetX::VMware::Mapper::validate_i_ge(-1),
+                :munge => PuppetX::VMware::Mapper::munge_to_i,
+              ],
+              :minUpTime => LeafData[
+                :validate => PuppetX::VMware::Mapper::validate_i_ge(1),
+                :munge => PuppetX::VMware::Mapper::munge_to_i,
+              ],
+              :vmMonitoring => LeafData[
+                :munge => PuppetX::VMware::Mapper::munge_to_sym,
+                :valid_enum => [
+                    :vmMonitoringDisabled,
+                    :vmMonitoringOnly,
+                    :vmAndAppMonitoring,
+                ],
+              ],
+            },
+          },
+          :hostMonitoring => LeafData[
+              :desc => "Is host monitoring enabled? enabled or disabled",
+              :valid_enum => [:enabled, :disabled],
+          ],
+          :vmMonitoring => LeafData[
+            :prop_name => :das_config_vm_monitoring,
+            :munge => PuppetX::VMware::Mapper::munge_to_sym,
+            :valid_enum => [
+                :vmMonitoringDisabled,
+                :vmMonitoringOnly,
+                :vmAndAppMonitoring,
+            ],
+          ],
+        },
+      }
+
+      super
+    end
+  end
+
+end


### PR DESCRIPTION
- add factory method for Mapper maps
- move ClusterConfigSpecExMap to separate file and subdirectory
