### PR TITLE
bypass vcenter for individual host maintenance mode

### DIFF
--- a/tests/maintmode-esx-direct.pp
+++ b/tests/maintmode-esx-direct.pp
@@ -1,0 +1,39 @@
+# Copyright (C) 2013 VMware, Inc.
+import 'data.pp'
+
+$ensure_mm = absent
+
+transport { 'esx1':
+  username => $esx1['username'],
+  password => $esx1['password'],
+  server   => $esx1['hostname'],
+  options  => $vcenter['options'],
+}
+transport { 'esx2':
+  username => $esx2['username'],
+  password => $esx2['password'],
+  server   => $esx2['hostname'],
+  options  => $vcenter['options'],
+}
+transport { 'esx3':
+  username => $esx3['username'],
+  password => $esx3['password'],
+  server   => $esx3['hostname'],
+  options  => $vcenter['options'],
+}
+
+esx_maintmode { "${esx1['hostname']}:X":
+  ensure                    => $ensure_mm,
+  timeout                   => 0,
+  transport                 => Transport['esx1'],
+} ~>
+esx_maintmode { "${esx2['hostname']}:X":
+  ensure                    => $ensure_mm,
+  timeout                   => 0,
+  transport                 => Transport['esx2'],
+} ~>
+esx_maintmode { "${esx3['hostname']}:X":
+  ensure                    => $ensure_mm,
+  timeout                   => 0,
+  transport                 => Transport['esx3'],
+}

--- a/tests/sample_data.pp
+++ b/tests/sample_data.pp
@@ -31,32 +31,32 @@ $cluster3 = {
 
 $log_host = $vcenter['server']
 
-$esx_shared_password = 'happyHolidays'
 $esx_shared_username = 'root'
+$esx_shared_password = 'happyHolidays'
 
 $esx1 = {
-  'username' => $esx_shared_password,
-  'password' => $esx_shared_username,
+  'username' => $esx_shared_username,
+  'password' => $esx_shared_password,
   'hostname' => 'esx1.nosuchdomain.',
 }
 $esx2 = {
-  'username' => $esx_shared_password,
-  'password' => $esx_shared_username,
+  'username' => $esx_shared_username,
+  'password' => $esx_shared_password,
   'hostname' => 'esx2.nosuchdomain.',
 }
 $esx3 = {
-  'username' => $esx_shared_password,
-  'password' => $esx_shared_username,
+  'username' => $esx_shared_username,
+  'password' => $esx_shared_password,
   'hostname' => 'esx3.nosuchdomain.',
 }
 $esx4 = {
-  'username' => $esx_shared_password,
-  'password' => $esx_shared_username,
+  'username' => $esx_shared_username,
+  'password' => $esx_shared_password,
   'hostname' => 'esx4.nosuchdomain.',
 }
 $esxA = {
-  'username' => $esx_shared_password,
-  'password' => $esx_shared_username,
+  'username' => $esx_shared_username,
+  'password' => $esx_shared_password,
   'hostname' => 'nosuchhost.',
 }
 


### PR DESCRIPTION
- enter or exit maintenance mode
- allows enter maintenance mode before adding to vcenter
  confused username/password on individual esx hosts
- assign shared_username to username, not to password
- assign shared_password to password, not to username
