### PR TITLE
Add vc_storagepod resource type.

### DIFF
--- a/lib/puppet/provider/vc_storagepod/default.rb
+++ b/lib/puppet/provider/vc_storagepod/default.rb
@@ -1,0 +1,73 @@
+# Copyright (C) 2013 VMware, Inc.
+
+provider_path = Pathname.new(__FILE__).parent.parent
+require File.join(provider_path, 'vcenter')
+
+Puppet::Type.type(:vc_storagepod).provide(:vc_storagepod, :parent => Puppet::Provider::Vcenter) do
+  
+  @doc = "This resource allows for the creation of a Storage Cluster, as well as the addition of datastores to the Cluster."
+
+  def create
+    to_add        = []
+    root_ds_names = ds.map{|d| d.name}
+    @resource[:datastores].each do |ds_name|
+      if root_ds_names.include?(ds_name)
+        to_add << ds.find{|d| d.name == ds_name}
+      else 
+        fail "datastore object #{ds_name} not found"
+      end
+    end
+    pod_ = dc.datastoreFolder.CreateStoragePod(:name => @resource[:name])
+    pod_.MoveIntoFolder_Task(:list => to_add).wait_for_completion unless to_add.empty?
+  end
+
+  def destroy
+    pod.Destroy_Task.wait_for_completion
+  end
+
+  def exists?
+    pod
+  end
+
+  def datastores
+    pod.children.map{|ds| ds.name}
+  end
+  
+  def datastores=(values)
+    #remove from cluster
+    to_remove = []
+    pod.children.each do |child|
+      to_remove << child unless values.include?(child.name)
+    end
+    #add to cluster
+    to_add           = []
+    cluster_ds_names = datastores
+    root_ds_names    = ds.map{|d| d.name}
+    values.each do |ds_name|
+      if cluster_ds_names.include?(ds_name)
+        #
+      elsif root_ds_names.include?(ds_name)
+        to_add << ds.find{|d|d.name == ds_name}
+      else
+        fail "datastore object #{ds_name} not found"
+      end
+    end
+    dc.datastoreFolder.MoveIntoFolder_Task(:list => to_remove).wait_for_completion unless to_remove.empty?
+    pod.MoveIntoFolder_Task(:list => to_add).wait_for_completion unless to_add.empty?
+  end
+      
+  private
+  
+  def dc
+    @dc ||= locate(@resource[:datacenter], RbVmomi::VIM::Datacenter)
+  end
+
+  def pod
+    @pod ||= dc.datastoreFolder.children.select{|d| RbVmomi::VIM::StoragePod === d}.find{|d|d.name == @resource[:name]}
+  end
+
+  def ds
+    @ds ||= dc.datastoreFolder.children.select{|d| RbVmomi::VIM::Datastore === d}
+  end
+
+end

--- a/lib/puppet/type/vc_storagepod.rb
+++ b/lib/puppet/type/vc_storagepod.rb
@@ -1,0 +1,31 @@
+# Copyright (C) 2013 VMware, Inc.
+Puppet::Type.newtype(:vc_storagepod) do
+
+  @doc = "Manage Storage Pods (clusters)"
+
+  newparam(:cluster, :namevar => true) do
+    desc "Name of the cluster to be used"
+  end
+
+  newparam(:datacenter) do
+    desc "Datacenter in which the cluster will be used"
+  end
+
+  ensurable do
+    newvalue(:present) do
+      provider.create
+    end
+
+    newvalue(:absent) do
+      provider.destroy
+    end
+
+    defaultto(:present)
+  end
+
+  newproperty(:datastores, :array_matching => :all) do
+    desc "Datastores to be added to Storage Pod"
+    defaultto([])
+  end
+
+end

--- a/tests/vc_storagepod.pp
+++ b/tests/vc_storagepod.pp
@@ -1,0 +1,15 @@
+import 'data.pp'
+
+transport { 'vcenter':
+  username => $vcenter['username'],
+  password => $vcenter['password'],
+  server   => $vcenter['server'],
+  options  => $vcenter['options'],
+}
+
+vc_storagepod {'ds-cluster':
+  ensure     => present,
+  datacenter => 'dev-dc',
+  transport  => Transport['vcenter'],
+  datastores => ['esx-lun0', 'esx-lun1'],
+}


### PR DESCRIPTION
This add a resource type for creating, editing, and removing Datastore Clusters.  The vSphere API calls Datastore Clusters `storagePods`.  This resource does not support SDRS (Storage DRS), only the creation of a Cluster, addition and removal of Datastores to or from a new or existing cluster, or the removal of an existing cluster.  Datastores removed from a cluster are placed back in the "root" `dc.datastoreFolder` folder.
