### PR TITLE
Modulefile version fix for librarian-puppet

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,7 +9,7 @@ project_page 'https://github.com/puppetlabs/vmware-vcenter'
 moduledir = File.dirname(__FILE__)
 ENV['GIT_DIR'] = moduledir + '/.git'
 
-git_version = %x{git describe --dirty --tags}.chomp.sub(/\.([0-9]+)-/) {|v| ".#{v[1..-2].to_i(10) + 1}-" }
+git_version = %x{git describe --dirty --tags}.chomp.split('-')[0]
 unless $?.success? and git_version =~ /^\d+\.\d+\.\d+/
   raise "Unable to determine version using git: #{$?} => #{git_version.inspect}"
 end


### PR DESCRIPTION
- Strips the dynamic elements added by git to the version (commits since last tag, hash).
