### PR TITLE
ESX advanced options

### DIFF
--- a/lib/puppet/provider/esx_advanced_options/default.rb
+++ b/lib/puppet/provider/esx_advanced_options/default.rb
@@ -1,0 +1,58 @@
+# Copyright (C) 2013 VMware, Inc.
+provider_path = Pathname.new(__FILE__).parent.parent
+require File.join(provider_path, 'vcenter')
+
+Puppet::Type.type(:esx_advanced_options).provide(:esx_advanced_options, :parent => Puppet::Provider::Vcenter) do
+  @doc = "Manages vCenter hosts' advanced options."
+
+  def initialize(args)
+    @changed_keys = []
+
+    super(args)
+  end
+
+  def options
+    value = {}
+    resource[:options].keys.each do |optkey|
+      v = host.configManager.advancedOption.QueryOptions(:name => optkey)[0].value
+      v = v.to_s if Integer === v
+      value[optkey] = v
+      @changed_keys.push(optkey) if v != resource[:options][optkey]
+    end
+    value
+  rescue RbVmomi::Fault
+    Puppet.debug "ESX advanced options #{resource[:options]} -- get failed for " +
+        "key '#{optkey}'"
+    fail "property '#{optkey}' not found in map"
+  end
+
+  def options=(value)
+    changedValue = []
+    @changed_keys.each do |optkey|
+      optvalue = cast_option(optkey, value[optkey])
+      changedValue.push({:key => optkey, :value => optvalue})
+    end
+    host.configManager.advancedOption.UpdateOptions(:changedValue => changedValue) if changedValue != []
+  end
+
+  private
+
+  def cast_option(key, value)
+    optdef = host.configManager.advancedOption.supportedOption.find{|so| so[:key] == key}
+    case optdef.optionType.class.to_s
+    when "IntOption"
+      RbVmomi::BasicTypes::Int.new value.to_i
+    when "LongOption"
+      value.to_i
+    else
+      value
+    end
+  end
+
+  def host
+    @host ||= vim.searchIndex.FindByDnsName(:dnsName => resource[:host], :vmSearch => false) ||
+        fail("host #{resource[:host]} not found")
+  end
+
+end
+

--- a/lib/puppet/type/esx_advanced_options.rb
+++ b/lib/puppet/type/esx_advanced_options.rb
@@ -1,0 +1,18 @@
+# Copyright (C) 2013 VMware, Inc.
+Puppet::Type.newtype(:esx_advanced_options) do
+  @doc = "Manage vCenter esx advanced options."
+
+  newparam(:host, :namevar => true) do
+    desc "ESX hostname or ip address."
+  end
+
+  newproperty(:options) do
+    desc "a hash with options and values"
+  end
+
+  autorequire(:vc_host) do
+    # autorequire esx host.
+    self[:name]
+  end
+
+end

--- a/tests/esx_advanced_options.pp
+++ b/tests/esx_advanced_options.pp
@@ -1,0 +1,21 @@
+# Copyright (C) 2013 VMware, Inc.
+import 'data.pp'
+
+transport { 'vcenter':
+  username => $vcenter['username'],
+  password => $vcenter['password'],
+  server   => $vcenter['server'],
+  options  => $vcenter['options'],
+}
+
+esx_advanced_options { $esx1['hostname']:
+  options => { 
+  "Vpx.Vpxa.config.log.level" => "verbose",                          # ChoiceOption  default "verbose"
+  "Config.HostAgent.log.level" => "verbose",                         # ChoiceOption  default "verbose"
+  "Annotations.WelcomeMessage" => "",                                # StringOption  default ""
+  "BufferCache.SoftMaxDirty" => 15,                                  # LongOption    default 15
+  "CBRC.Enable" => false,                                            # BoolOption    default false
+  "Config.GlobalSettings.guest.commands.sharedPolicyRefCount" => 0   # IntOption     default 0
+  },
+  transport      => Transport['vcenter'],
+}


### PR DESCRIPTION
Generic resource for manipulation of ESX advanced options.  

Accepts a single input (options) as a hash of key/value pairs.  
