### PR TITLE
Network Resource Pools

### DIFF
--- a/lib/puppet/provider/vc_dvswitch_pool/default.rb
+++ b/lib/puppet/provider/vc_dvswitch_pool/default.rb
@@ -1,0 +1,78 @@
+# Copyright (C) 2013 VMware, Inc.
+provider_path = Pathname.new(__FILE__).parent.parent
+require File.join(provider_path, 'vcenter')
+
+Puppet::Type.type(:vc_dvswitch_pool).provide(:vc_dvswitch_pool, :parent => Puppet::Provider::Vcenter) do
+  @doc = "Manage dvSwitch network resource pools"
+
+  Puppet::Type.type(:vc_dvswitch_pool).properties.collect{|x| x.name}.each do |prop|
+
+    prop_sym = PuppetX::VMware::Util.camelize(prop, :lower).to_sym
+
+    define_method(prop) do
+      case prop_sym
+      when :limit, :priorityTag
+        resource_pool.allocationInfo[prop_sym].to_s
+      when :shares, :level
+        resource_pool.allocationInfo.shares[prop_sym].to_s
+      else
+        resource_pool[prop_sym].to_s
+      end
+    end
+
+    define_method("#{prop}=") do |value|
+      @flush_required = true
+      case prop_sym
+      when :limit, :priorityTag
+        config_spec.allocationInfo[prop_sym] = value
+      when :shares
+        config_spec.allocationInfo.shares[prop_sym] = value
+      when :level
+        config_spec.allocationInfo.shares[prop_sym] = RbVmomi::VIM::SharesLevel.new(value.to_sym)
+      else
+        config_spec[prop_sym] = value
+      end
+    end
+  end
+
+  def flush
+    if @flush_required
+      dvswitch.UpdateNetworkResourcePool(:configSpec => [config_spec])
+    end
+  end
+
+  private
+
+  def dvswitch
+    @dvswitch ||= begin
+      dc = vim.serviceInstance.find_datacenter(parent(@resource[:dvswitch_path]))
+      dvswitches = dc.networkFolder.children.select {|n|
+        n.class == RbVmomi::VIM::VmwareDistributedVirtualSwitch
+      }
+      dvswitches.find{|d| d.name == @resource[:dvswitch_name]}
+    end
+    fail "dvswitch not found." unless @dvswitch
+    @dvswitch
+  end
+
+  # Creates a new DVSNetworkResourcePoolConfigSpec populated with existing parameters
+  def config_spec
+    @config_spec ||= begin
+      spec = RbVmomi::VIM::DVSNetworkResourcePoolConfigSpec.new
+      spec.name = resource_pool.name.dup
+      spec.key = resource_pool.key.dup
+      spec.description = resource_pool.description.dup
+      spec.allocationInfo = resource_pool.allocationInfo.dup
+      spec.allocationInfo.shares = resource_pool.allocationInfo.shares.dup
+      spec.allocationInfo.shares.level = resource_pool.allocationInfo.shares.level.dup
+      spec
+    end
+  end
+
+  def resource_pool
+    @resource_pool ||= dvswitch.networkResourcePool.find{|nrp| nrp.key == @resource[:key]}
+    fail "resource pool #{@resource[:key]} not found." unless @resource_pool
+    @resource_pool
+  end
+
+end

--- a/lib/puppet/type/vc_dvswitch_pool.rb
+++ b/lib/puppet/type/vc_dvswitch_pool.rb
@@ -1,0 +1,55 @@
+# Copyright (C) 2013 VMware, Inc.
+Puppet::Type.newtype(:vc_dvswitch_pool) do
+  @doc = "Manages vCenter Distributed Virtual Switch "\
+         "Network Resource Pool Management"
+
+  newparam(:name, :namevar => true) do
+    desc "{path to dvswitch}:{network resource pool key}"
+
+    munge do |value|
+      @resource[:dvswitch_path], @resource[:key] = value.split(':',2)
+      value
+    end
+  end
+
+  newparam(:dvswitch_path) do
+    desc "The path to the dvportgroup."
+    validate do |value|
+      raise "Absolute path required: #{value}" unless Puppet::Util.absolute_path?(value)
+    end
+    munge do |value|
+      @resource[:dvswitch_name] = value.split('/')[-1]
+      value
+    end
+  end
+
+  newparam(:dvswitch_name) do
+  end
+
+  newproperty(:key) do
+    desc "pool identifier"
+  end
+
+  newproperty(:limit) do
+    desc ""
+  end
+
+  newproperty(:priority_tag) do
+    desc "QOS priority tag"
+  end
+
+  newproperty(:shares) do
+    desc "network shares"
+  end
+
+  newproperty(:level) do
+    desc "Share level ('custom', 'high', 'low', 'normal')"
+    newvalues(:custom, :high, :low, :normal)
+  end
+
+  # autorequire datacenter
+  autorequire(:vc_dvswitch) do
+    self[:dvswitch_path]
+  end
+
+end

--- a/tests/dvswitch_qos.pp
+++ b/tests/dvswitch_qos.pp
@@ -1,0 +1,16 @@
+# Copyright (C) 2013 VMware, Inc.
+import 'data.pp'
+
+transport { 'vcenter':
+  username => "${vcenter['username']}",
+  password => "${vcenter['password']}",
+  server   => "${vcenter['server']}",
+  options  => $vcenter['options'],
+}
+
+vc_dvswitch_pool { "${dc1['path']}/dvs1:nfs":
+  level => 'custom',
+  shares => 97,
+  priority_tag => 7,
+  transport => Transport['vcenter'],
+}


### PR DESCRIPTION
- Adds support for editing properties of built-in dvSwitch network
  resource pools.
- Some properties (description, name) of the built-in pools are not
  able to be changed.
- No support for custom pools at this time as they use dynamically
  generated keys which results in duplicate custom pools being
  generated on subsequent calls to the resource.
