### PR TITLE
rest-client gem version

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -5,7 +5,7 @@ class vcenter::package (
   package { [
     'rest-client',
   ]:
-    ensure   => present,
+    ensure   => '1.6.7',
     provider => $::vcenter::params::provider,
   }
 


### PR DESCRIPTION
-Recently noticed issues when using rest-client gem version 1.7.2 so I am statically setting the gem version until we can determine the issue and if possible bring it up to date with newer gem version.