### PR TITLE
make available gem version for puppet - rest-client 1.6.7

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -2,11 +2,13 @@
 class vcenter::package (
 ) inherits vcenter::params {
 
-  package { [
-    'rest-client',
-  ]:
-    ensure   => present,
-    provider => $::vcenter::params::provider,
+  # rest-client gem 1.6.7 until problems with current gem are fixed
+  $rest_client_version = '1.6.7'
+
+  package { 'rest-client':
+    ensure          => $rest_client_version,
+    install_options => [ '--no-ri', '--no-rdoc' ],
+    provider        => $::vcenter::params::provider,
   }
 
   # net-ssh gem 2.1.4 (PE3) is incompatible with vcsa 5.5 security settings:

--- a/tests/package_test.pp
+++ b/tests/package_test.pp
@@ -1,0 +1,5 @@
+# Copyright 2014 VMware, Inc.
+# this manifest is for test purposes
+# vcenter::package should be invoked centrally
+
+class { 'vcenter::package': }


### PR DESCRIPTION
* tests/package_test.pp supplied for testing
* don't remove other versions
* leave it to modules that need specific version to require it