### PR TITLE
Manage VM virtual hardware configurations

### DIFF
--- a/lib/puppet/provider/vc_vm/default.rb
+++ b/lib/puppet/provider/vc_vm/default.rb
@@ -98,29 +98,6 @@ Puppet::Type.type(:vc_vm).provide(:vc_vm, :parent => Puppet::Provider::Vcenter) 
 
   private
 
-  def findvm(folder,vm_name)
-    folder.children.each do |f|
-      break if @vm_obj
-      case f
-      when RbVmomi::VIM::Folder
-        findvm(f,vm_name)
-      when RbVmomi::VIM::VirtualMachine
-        @vm_obj = f if f.name == vm_name
-      when RbVmomi::VIM::VirtualApp
-        f.vm.each do |v|
-          if v.name == vm_name
-            @vm_obj = f
-            break
-          end
-        end
-      else
-        puts "unknown child type found: #{f.class}"
-        exit
-      end
-    end
-    @vm_obj
-  end
-
   def datacenter(name=resource[:datacenter_name])
     vim.serviceInstance.find_datacenter(name) or raise Puppet::Error, "datacenter '#{name}' not found."
   end

--- a/lib/puppet/provider/vcenter.rb
+++ b/lib/puppet/provider/vcenter.rb
@@ -66,7 +66,30 @@ class Puppet::Provider::Vcenter <  Puppet::Provider
     end
   end
 
-  def findvm(folder)
+  def findvm(folder,vm_name)
+    folder.children.each do |f|
+      break if @vm_obj
+      case f
+      when RbVmomi::VIM::Folder
+        findvm(f,vm_name)
+      when RbVmomi::VIM::VirtualMachine
+        @vm_obj = f if f.name == vm_name
+      when RbVmomi::VIM::VirtualApp
+        f.vm.each do |v|
+          if v.name == vm_name
+            @vm_obj = f
+            break
+          end
+        end
+      else
+        puts "unknown child type found: #{f.class}"
+        exit
+      end
+    end
+    @vm_obj
+  end
+
+  def findvms(folder)
     vms = []
     folder.children.each do |c|
       puts c.class

--- a/lib/puppet/provider/vcenter.rb
+++ b/lib/puppet/provider/vcenter.rb
@@ -82,8 +82,7 @@ class Puppet::Provider::Vcenter <  Puppet::Provider
           end
         end
       else
-        puts "unknown child type found: #{f.class}"
-        exit
+        Puppet.warning "findvm: unknown child type found: #{f.class}"
       end
     end
     @vm_obj

--- a/lib/puppet/provider/vm_harddisk/default.rb
+++ b/lib/puppet/provider/vm_harddisk/default.rb
@@ -1,0 +1,246 @@
+# Copyright (C) 2014 VMware, Inc.
+vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
+require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
+require File.join vmware_module.path, 'lib/puppet/property/vmware'
+module_lib    = Pathname.new(__FILE__).parent.parent.parent.parent
+require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet/provider/vcenter'
+
+Puppet::Type.type(:vm_harddisk).provide(:vm_harddisk, :parent => Puppet::Provider::Vcenter) do
+  @doc = "Manage a vCenter VM's virtual disk settings. See http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.device.VirtualDisk.html for class details"
+
+  ##### begin common provider methods #####
+  # besides name, these methods should look exactly the same for all providers
+  # ensurable resources will have create, create_message, exist? and destroy
+
+  map ||= PuppetX::VMware::Mapper.new_map('VirtualDiskMap')
+
+  def create
+    @flush_required = true
+    @create_message ||= []
+    # fetch properties from resource using provider setters
+    map.leaf_list.each do |leaf|
+      p = leaf.prop_name
+      unless (value = @resource[p]).nil?
+        self.send("#{p}=".to_sym, value)
+        @create_message << "#{leaf.full_name} => #{value.inspect}"
+      end
+    end
+  end
+
+  def create_message
+    @create_message ||= []
+    "created using {#{@create_message.join ", "}}"
+  end
+
+  define_method(:map) do
+    @map ||= map
+  end
+
+  map.leaf_list.each do |leaf|
+    Puppet.debug "Auto-discovered property [#{leaf.prop_name}] for type [#{self.name}]"
+
+    define_method(leaf.prop_name) do
+      Puppet.debug "#{leaf.path_is_now} set to #{PuppetX::VMware::Util::nested_value(config_is_now, leaf.path_is_now)}"
+      value = PuppetX::VMware::Mapper::munge_to_tfsyms.call(
+        PuppetX::VMware::Util::nested_value(config_is_now, leaf.path_is_now)
+      )
+    end
+
+    define_method("#{leaf.prop_name}=".to_sym) do |value|
+      PuppetX::VMware::Util::nested_value_set config_should, leaf.path_should, value, transform_keys=false
+      @flush_required = true
+    end
+  end
+
+  def exists?
+    config_is_now
+  end
+
+  def config_should
+    @config_should ||= config_hash config_is_now
+  end
+
+  ##### begin standard provider methods #####
+  # these methods should exist in all ensurable providers, but content will diff
+
+  def config_is_now
+    @config_is_now ||= virtualDisk 
+  end
+
+  def flush
+    if @flush_required
+      operation = config_is_now ? :edit : :add
+      reconfigVM( operation )
+    end
+  end
+
+  def destroy
+    reconfigVM( :remove )
+  end
+
+  ##### begin misc provider specific methods #####
+  # This section is for overrides of automatically-generated property getters and setters. Many
+  # providers don't need any overrides. The most common use of overrides is to allow user input
+  # of component names instead of object IDs (REST APIs) or Managed Object References (SOAP APIs).
+  alias set_level level=
+  # Override level= to include setting the shares based off Enum SharesInfo http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.SharesInfo.Level.html
+  def level=(value)
+    @flush_required = true
+    self.set_level value.to_s
+    case value
+    when :high
+      num_shares=2000
+    when :normal
+      num_shares=1000
+    when :low
+      num_shares=500
+    when :custom
+      raise Puppet::Error, "#{resource.inspect} must include propety 'shares' when setting 'level' to 'custom'" unless resource[:shares]
+      num_shares=resource[:shares]
+    end
+    self.shares=num_shares
+  end
+
+  # Override attributes of backing because map.objectify has issues with the backing class
+  alias set_disk_mode disk_mode=
+  def disk_mode=(value)
+    @flush_required = true
+    backing.diskMode = value.to_s
+  end
+
+  alias set_write_through write_through=
+  def write_through=(value)
+    @flush_required = true
+    backing.writeThrough = value.to_s 
+  end
+
+  # Override controller to convert display name into controllerKey
+  alias get_controller controller
+  def controller
+    currentController = vm.config.hardware.device.find { |d| d.key == config_is_now[:controllerKey] }
+    currentController.deviceInfo.label if currentController
+  end
+
+  alias set_controller controller=
+  def controller=(value)
+    @flush_required = true
+    config_should[:controllerKey] = newController.key
+    config_should[:unitNumber]    = unitNumber
+  end
+
+  ##### begin private provider specific methods section #####
+  # These methods are provider specific and that can be private
+  private
+ 
+  # Convert config_is_now into a hash to work with PuppetX::VMware::Util::nested_value
+  # Removes backing from hash because map.objectify has issues with backing class
+  def config_hash(config)
+    newHash = {}
+    if config
+      nodes = []
+      map.node_list.each { |node| nodes << node.node_type}
+      config.props.each do |k,v|
+        if nodes.include? v.class.to_s
+          newHash[k] = config_hash v
+        else
+          newHash[k] = v
+        end
+      end
+      newHash.delete(:backing)
+    else
+      newHash[:key] = -100
+    end
+    newHash
+  end
+
+  def datacenter(name=resource[:datacenter])
+    vim.serviceInstance.find_datacenter(name) or raise Puppet::Error, "datacenter '#{resource[:datacenter]}' not found."
+  end
+
+  def vm
+    @vm ||= findvm(datacenter.vmFolder, resource[:vm_name]) or raise Puppet::Error, "Unable to locate VM with the name '#{resource[:vm_name]}' "
+  end
+
+  def datastore
+    @datastore ||= datacenter.datastoreFolder.children.find { |d| d.name.downcase == resource[:datastore].downcase } or raise Puppet::Error, "#{resource.inspect} unable to locate datastore '#{resource[:datastore]}' in datacenter '#{resource[:datacenter]}'"
+  end
+
+  def virtualDisk
+    vm.config.hardware.device.find { |d| d.deviceInfo.label.downcase == resource[:name].downcase }
+  end
+
+  def reconfigVM(operation)
+    vm.ReconfigVM_Task(
+      :spec => virtualMachineConfigSpec( operation )
+    ).wait_for_completion
+  end
+
+  def virtualMachineConfigSpec(operation)
+    deviceSpec = map.objectify config_should
+    # Add backing back in after map.objectify
+    deviceSpec.backing = backing 
+    spec = {
+      :operation => operation,
+      :device    => deviceSpec
+    }
+    spec.merge!( :fileOperation => :create ) if operation == :add
+    spec.merge!( :fileOperation => :destroy ) if resource[:remove_disk] && operation == :remove
+    virtualDeviceConfigSpec = RbVmomi::VIM::VirtualDeviceConfigSpec( spec )
+    @virtualMachineConfigSpec = RbVmomi::VIM::VirtualMachineConfigSpec(
+      :deviceChange => [ virtualDeviceConfigSpec ]
+    )
+  end
+
+  def backing
+    @backing ||= config_is_now ? config_is_now[:backing] : virtualDiskFlatVer2BackingInfo 
+  end
+
+  def virtualDiskFlatVer2BackingInfo
+    b = RbVmomi::VIM::VirtualDiskFlatVer2BackingInfo.new(:thinProvisioned => resource[:thin_provisioned].to_s, :fileName => fileName)
+    b.eagerScrub = resource[:eager_scrub] if resource.to_hash.has_key? :eager_scrub
+    b
+  end
+
+  def newController
+    @newController ||= vm.config.hardware.device.find { |d| d.deviceInfo.label.downcase == resource[:controller].downcase } or raise Puppet::Error, "#{resource.inspect} unable to locate controller '#{resource[:controller]}' on VM '#{resource[:vm_name]}'"
+  end
+
+  def unitNumber
+    used = []
+    vm.config.hardware.device.each { |d| used << d.unitNumber if d.controllerKey == newController.key }
+    (0..15).each do |id|
+      break if @unitNumber
+      @unitNumber ||= id unless used.include? id || id = 7
+    end
+    Puppet.debug "#{resource[:controller]} setting unitNumber to '#{@unitNumber}'"
+    @unitNumber
+  end
+
+  def fileName
+    "[#{datastore.name}] #{resource[:vm_name]}/#{resource[:vm_name]}#{fileSuffix}"
+  end
+
+  def fileSuffix
+    used = []
+    vm.disks.each do |disk|
+      vmdk = disk.backing.fileName.split('/')[1]
+      if vmdk == "#{resource[:vm_name]}.vmdk"
+        used << 0
+      else
+        used << vmdk.slice(/_\d.vmdk/).slice(/\d/).to_i
+      end
+    end
+    #Max number of SCSI targers per VM https://www.vmware.com/pdf/vsphere5/r55/vsphere-55-configuration-maximums.pdf
+    (0..60).each do |id|
+      break if @suffixId
+      @suffixId ||= id unless used.include? id
+    end
+    if @suffixId == 0
+      suffix = ".vmdk"
+    else
+      suffix = "_#{@suffixId}.vmdk"
+    end
+    suffix
+  end
+end

--- a/lib/puppet/provider/vm_harddisk/default.rb
+++ b/lib/puppet/provider/vm_harddisk/default.rb
@@ -96,7 +96,7 @@ Puppet::Type.type(:vm_harddisk).provide(:vm_harddisk, :parent => Puppet::Provide
     when :low
       num_shares=500
     when :custom
-      raise Puppet::Error, "#{resource.inspect} must include propety 'shares' when setting 'level' to 'custom'" unless resource[:shares]
+      raise Puppet::Error, "#{resource.inspect} must include property 'shares' when setting 'level' to 'custom'" unless resource[:shares]
       num_shares=resource[:shares]
     end
     self.shares=num_shares
@@ -198,7 +198,7 @@ Puppet::Type.type(:vm_harddisk).provide(:vm_harddisk, :parent => Puppet::Provide
 
   def virtualDiskFlatVer2BackingInfo
     b = RbVmomi::VIM::VirtualDiskFlatVer2BackingInfo.new(:thinProvisioned => resource[:thin_provisioned].to_s, :fileName => fileName)
-    b.eagerScrub = resource[:eager_scrub] if resource.to_hash.has_key? :eager_scrub
+    b.eagerScrub = resource[:eager_scrub] unless resource[:eager_scrub].nil?
     b
   end
 

--- a/lib/puppet/provider/vm_hardware/default.rb
+++ b/lib/puppet/provider/vm_hardware/default.rb
@@ -69,27 +69,4 @@ Puppet::Type.type(:vm_hardware).provide(:vm_hardware, :parent => Puppet::Provide
     vm.config.hardware
   end
 
-  def findvm(folder,vm_name)
-    folder.children.each do |f|
-      break if @vm_obj
-      case f
-      when RbVmomi::VIM::Folder
-        findvm(f,vm_name)
-      when RbVmomi::VIM::VirtualMachine
-        @vm_obj = f if f.name == vm_name
-      when RbVmomi::VIM::VirtualApp
-        f.vm.each do |v|
-          if v.name == vm_name
-            @vm_obj = f
-            break
-          end
-        end
-      else
-        puts "unknown child type found: #{f.class}"
-        exit
-      end
-    end
-    @vm_obj
-  end
-
 end

--- a/lib/puppet/provider/vm_hardware/default.rb
+++ b/lib/puppet/provider/vm_hardware/default.rb
@@ -1,0 +1,95 @@
+# Copyright (C) 2014 VMware, Inc.
+vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
+require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
+require File.join vmware_module.path, 'lib/puppet/property/vmware'
+module_lib    = Pathname.new(__FILE__).parent.parent.parent.parent
+require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet/provider/vcenter'
+
+Puppet::Type.type(:vm_hardware).provide(:vm_hardware, :parent => Puppet::Provider::Vcenter) do
+  @doc = "Manage a vCenter VM's virtual hardware settings. See http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.VirtualHardware.html for class details"
+
+  ##### begin common provider methods #####
+  # besides name, these methods should look exactly the same for all providers
+  # ensurable resources will have create, create_message, exist? and destroy
+
+  map ||= PuppetX::VMware::Mapper.new_map('VirtualHardwareMap')
+
+  define_method(:map) do
+    @map ||= map
+  end
+
+  map.leaf_list.each do |leaf|
+    Puppet.debug "Auto-discovered property [#{leaf.prop_name}] for type [#{self.name}]"
+
+    define_method(leaf.prop_name) do
+      value = PuppetX::VMware::Mapper::munge_to_tfsyms.call(
+        PuppetX::VMware::Util::nested_value(config_is_now, leaf.path_is_now)
+      )
+    end
+
+    define_method("#{leaf.prop_name}=".to_sym) do |value|
+      PuppetX::VMware::Util::nested_value_set config_should, leaf.path_should, value, transform_keys=false
+      @flush_required = true
+    end
+  end
+
+  def config_should
+    @config_should ||= {}
+  end
+
+  ##### begin standard provider methods #####
+  # these methods should exist in all ensurable providers, but content will diff
+
+  def config_is_now
+    @config_is_now ||= hardware
+  end
+
+  def flush
+    if @flush_required
+      vm.ReconfigVM_Task(
+       :spec => RbVmomi::VIM::VirtualMachineConfigSpec( config_should )
+      ).wait_for_completion
+    end
+  end
+
+  ##### begin private provider specific methods section #####
+  # These methods are provider specific and that can be private
+  private
+ 
+  def datacenter(name=resource[:datacenter])
+    vim.serviceInstance.find_datacenter(name) or raise Puppet::Error, "datacenter '#{resource[:datacenter]}' not found."
+  end
+
+  def vm
+    @vm ||= findvm(datacenter.vmFolder, resource[:vm_name]) or raise Puppet::Error, "Unable to locate VM with the name '#{resource[:vm_name]}' "
+  end
+
+  def hardware
+    vm.config.hardware
+  end
+
+  def findvm(folder,vm_name)
+    folder.children.each do |f|
+      break if @vm_obj
+      case f
+      when RbVmomi::VIM::Folder
+        findvm(f,vm_name)
+      when RbVmomi::VIM::VirtualMachine
+        @vm_obj = f if f.name == vm_name
+      when RbVmomi::VIM::VirtualApp
+        f.vm.each do |v|
+          if v.name == vm_name
+            @vm_obj = f
+            break
+          end
+        end
+      else
+        puts "unknown child type found: #{f.class}"
+        exit
+      end
+    end
+    @vm_obj
+  end
+
+end

--- a/lib/puppet/provider/vm_nic/default.rb
+++ b/lib/puppet/provider/vm_nic/default.rb
@@ -204,29 +204,6 @@ Puppet::Type.type(:vm_nic).provide(:vm_nic, :parent => Puppet::Provider::Vcenter
     )
   end
 
-  def findvm(folder,vm_name)
-    folder.children.each do |f|
-      break if @vm_obj
-      case f
-      when RbVmomi::VIM::Folder
-        findvm(f,vm_name)
-      when RbVmomi::VIM::VirtualMachine
-        @vm_obj = f if f.name == vm_name
-      when RbVmomi::VIM::VirtualApp
-        f.vm.each do |v|
-          if v.name == vm_name
-            @vm_obj = f
-            break
-          end
-        end
-      else
-        puts "unknown child type found: #{f.class}"
-        exit
-      end
-    end
-    @vm_obj
-  end
-
   def datacenter(name=resource[:datacenter])
     vim.serviceInstance.find_datacenter(name) or raise Puppet::Error, "datacenter '#{resource[:datacenter]}' not found."
   end

--- a/lib/puppet/provider/vm_nic/default.rb
+++ b/lib/puppet/provider/vm_nic/default.rb
@@ -1,0 +1,238 @@
+# Copyright (C) 2014 VMware, Inc.
+vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
+require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
+require File.join vmware_module.path, 'lib/puppet/property/vmware'
+module_lib    = Pathname.new(__FILE__).parent.parent.parent.parent
+require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet/provider/vcenter'
+
+Puppet::Type.type(:vm_nic).provide(:vm_nic, :parent => Puppet::Provider::Vcenter) do
+  @doc = "Manage a vCenter VM's virtual network adapter settings. See http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.device.VirtualEthernetCard.html for class details"
+
+  ##### begin common provider methods #####
+  # besides name, these methods should look exactly the same for all providers
+  # ensurable resources will have create, create_message, exist? and destroy
+
+  map ||= PuppetX::VMware::Mapper.new_map('VirtualEthernetCardMap')
+
+  define_method(:map) do
+    @map ||= map
+  end
+
+  def create
+    @flush_required = true
+    @create_message ||= []
+    # fetch properties from resource using provider setters
+    map.leaf_list.each do |leaf|
+      p = leaf.prop_name
+      unless (value = @resource[p]).nil?
+        self.send("#{p}=".to_sym, value)
+        @create_message << "#{leaf.full_name} => #{value.inspect}"
+      end
+    end
+  end
+
+  def create_message
+    @create_message ||= []
+    "created using {#{@create_message.join ", "}}"
+  end
+
+  map.leaf_list.each do |leaf|
+    Puppet.debug "Auto-discovered property [#{leaf.prop_name}] for type [#{self.name}]"
+
+    define_method(leaf.prop_name) do
+      Puppet.debug "#{leaf.path_is_now} set to #{PuppetX::VMware::Util::nested_value(config_is_now, leaf.path_is_now)}"
+      value = PuppetX::VMware::Mapper::munge_to_tfsyms.call(
+        PuppetX::VMware::Util::nested_value(config_is_now, leaf.path_is_now)
+      )
+    end
+
+    define_method("#{leaf.prop_name}=".to_sym) do |value|
+      PuppetX::VMware::Util::nested_value_set config_should, leaf.path_should, value, transform_keys=false
+      @flush_required = true
+    end
+  end
+
+  def exists?
+    Puppet.debug "Evaluating '#{resource.inspect}' => #{resource.to_hash}"
+    config_is_now
+  end
+
+  ##### begin standard provider methods #####
+  # these methods should exist in all ensurable providers, but content will diff
+
+  def config_should
+    @config_should ||= config_hash || {}
+  end
+
+  def config_is_now
+    @config_is_now ||= map.annotate_is_now(virtual_network_card) if virtual_network_card
+  end
+
+  def flush
+    if @flush_required
+      operation = config_is_now ? :edit : :add
+      reconfigVM( operation )
+    end
+  end
+
+  def destroy
+    reconfigVM( :remove )
+  end
+
+  ##### begin misc provider specific methods #####
+  # This section is for overrides of automatically-generated property getters and setters. Many
+  # providers don't need any overrides. The most common use of overrides is to allow user input
+  # of component names instead of object IDs (REST APIs) or Managed Object References (SOAP APIs).
+  alias get_portgroup portgroup
+  def portgroup
+    case config_is_now[:backing].class.to_s 
+    when 'VirtualEthernetCardDistributedVirtualPortBackingInfo'
+      pg = datacenter.network.find {|n| n.key == config_is_now[:backing][:port][:portgroupKey] if n.class.to_s == 'DistributedVirtualPortgroup'}
+      pg.name
+    when 'VirtualEthernetCardNetworkBackingInfo'
+      config_is_now[:backing][:deviceName]
+    else
+      raise Puppet::Error, "#{resource.inspect} returned unrecognized backing class: '#{config_is_now[:backing].class.to_s}'"
+    end
+  end
+
+  alias set_portgroup portgroup=
+  def portgroup=(value)
+    case resource[:portgroup_type]
+    when :distributed
+      port = RbVmomi::VIM::DistributedVirtualSwitchPortConnection(
+        :portgroupKey => distributedPortgroup.key,
+        :switchUuid   => distributedPortgroup.config.distributedVirtualSwitch.uuid
+      )
+      config_should[:backing] = RbVmomi::VIM::VirtualEthernetCardDistributedVirtualPortBackingInfo(:port => port)
+    when :standard
+      config_should[:backing] = RbVmomi::VIM::VirtualEthernetCardNetworkBackingInfo(
+        :deviceName => standardPortgroup.name,
+      )
+    else
+      raise Puppet::Error, "#{resource.inspect} missing parameter 'portgroup_type': valid values [distrubuted, standard]"
+    end
+    @flush_required = true
+  end
+
+  alias get_type type
+  def type
+    case virtual_network_card.class.to_s
+    when 'VirtualE1000'
+      'e1000'
+    when 'VirtualE1000e'
+      'e1000e'
+    when 'VirtualVmxnet2'
+      'vmxnet2'
+    when 'VirtualVmxnet3'
+      'vmxnet3'
+    else
+      raise Puppet::Error, "#{resource.inspect} returned an unrecognized network card type"
+    end
+  end
+
+  alias set_type type=
+  def type=(value)
+    @newType = true
+    @flush_required = true
+  end
+
+  ##### begin private provider specific methods section #####
+  # These methods are provider specific and that can be private
+  private
+
+  def config_hash
+    config = {}
+    if config_is_now
+      config[:connectable] = config_is_now[:connectable].props
+      config[:key]         = config_is_now[:key]
+    else
+      config[:key]         = -100
+    end
+    config
+  end
+ 
+  def virtual_network_card
+    vm.config.hardware.device.find { |d| d.deviceInfo.label.downcase == resource[:name].downcase }
+  end
+
+  def distributedPortgroup
+    @distributedPortgroup ||= datacenter.network.find {|n| n.name == resource[:portgroup] if n.class.to_s == 'DistributedVirtualPortgroup'} or raise Puppet::Error, "#{resource.inspect} unable to find distrubuted portgroup '#{resource[:portgroup]}' in datacenter '#{resource[:datacenter]}'."
+  end
+
+  def standardPortgroup
+    @standardPortgroup ||= datacenter.network.find {|n| n.name == resource[:portgroup] if n.class.to_s == 'Network'} or raise Puppet::Error, "#{resource.inspect} unable to find standard portgroup '#{resource[:portgroup]}' in datacenter '#{resource[:datacenter]}'."
+  end
+
+  def reconfigVM(operation)
+    vm.ReconfigVM_Task(
+      :spec => virtualMachineConfigSpec( operation )
+    ).wait_for_completion
+  end
+
+  def virtualMachineConfigSpec(operation)
+    deviceSpec = map.objectify config_should
+    if @newType
+      nicType = resource[:type]
+    else
+      nicType = config_is_now.class.to_s
+    end
+
+    deviceSpec = 
+     begin
+        case nicType
+        when :e1000, 'VirtualE1000'
+          RbVmomi::VIM::VirtualE1000( deviceSpec.props )
+        when :e1000e, 'VirtualE1000e'
+          RbVmomi::VIM::VirtualE1000e( deviceSpec.props )
+        when :vmxnet2, 'VirtualVmxnet2'
+          RbVmomi::VIM::VirtualVmxnet2( deviceSpec.props )
+        when :vmxnet3, 'VirtualVmxnet3'
+          RbVmomi::VIM::VirtualVmxnet3( deviceSpec.props )
+        end
+     end
+    spec = {
+      :operation => operation,
+      :device    => deviceSpec
+    }
+
+    virtualDeviceConfigSpec = RbVmomi::VIM::VirtualDeviceConfigSpec( spec )
+    
+    @virtualMachineConfigSpec = RbVmomi::VIM::VirtualMachineConfigSpec(
+      :deviceChange => [ virtualDeviceConfigSpec ]
+    )
+  end
+
+  def findvm(folder,vm_name)
+    folder.children.each do |f|
+      break if @vm_obj
+      case f
+      when RbVmomi::VIM::Folder
+        findvm(f,vm_name)
+      when RbVmomi::VIM::VirtualMachine
+        @vm_obj = f if f.name == vm_name
+      when RbVmomi::VIM::VirtualApp
+        f.vm.each do |v|
+          if v.name == vm_name
+            @vm_obj = f
+            break
+          end
+        end
+      else
+        puts "unknown child type found: #{f.class}"
+        exit
+      end
+    end
+    @vm_obj
+  end
+
+  def datacenter(name=resource[:datacenter])
+    vim.serviceInstance.find_datacenter(name) or raise Puppet::Error, "datacenter '#{resource[:datacenter]}' not found."
+  end
+
+  def vm
+    @vm ||= findvm(datacenter.vmFolder, resource[:vm_name]) or raise Puppet::Error, "Unable to locate VM with the name '#{resource[:vm_name]}' "
+  end
+
+end

--- a/lib/puppet/provider/vm_vapp_property/default.rb
+++ b/lib/puppet/provider/vm_vapp_property/default.rb
@@ -109,29 +109,6 @@ Puppet::Type.type(:vm_vapp_property).provide(:vm_vapp_property, :parent => Puppe
     property_key newkey
   end
 
-  def findvm(folder,vm_name)
-    folder.children.each do |f|
-      break if @vm_obj
-      case f
-      when RbVmomi::VIM::Folder
-        findvm(f,vm_name)
-      when RbVmomi::VIM::VirtualMachine
-        @vm_obj = f if f.name == vm_name
-      when RbVmomi::VIM::VirtualApp
-        f.vm.each do |v|
-          if v.name == vm_name
-            @vm_obj = f
-            break
-          end
-        end
-      else
-        puts "unknown child type found: #{f.class}"
-        exit
-      end
-    end
-    @vm_obj
-  end
-
   def datacenter(name=resource[:datacenter])
     vim.serviceInstance.find_datacenter(name) or raise Puppet::Error, "datacenter '#{resource[:datacenter]}' not found."
   end

--- a/lib/puppet/type/vm_harddisk.rb
+++ b/lib/puppet/type/vm_harddisk.rb
@@ -1,0 +1,97 @@
+# Copyright (C) 2015 VMware, Inc.
+require 'pathname'
+module_lib    = Pathname.new(__FILE__).parent.parent.parent
+vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
+require File.join vmware_module.path, 'lib/puppet/property/vmware'
+require File.join module_lib, 'puppet_x/vmware/mapper'
+
+Puppet::Type.newtype(:vm_harddisk) do
+  @doc = "Manage a vCenter VM's virtual disk settings. See http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.device.VirtualDisk.html for class details"
+
+  #### create parameters ####
+  # the parameters are specific data points needed to set the properties pulled in by mapper and may change between types 
+  ensurable do
+    newvalue(:present) do
+      provider.create
+    end
+
+    newvalue(:absent) do
+      provider.destroy
+    end
+
+    defaultto(:present)
+
+    def change_to_s(is, should)
+      if should == :present
+        provider.create_message
+      else
+        "removed"
+      end
+    end
+  end
+
+  newparam(:name) do
+    desc "The display label of the virtual hard disk"
+  end
+
+  newparam(:vm_name) do
+    desc "The name of the target VM"
+  end
+
+  newparam(:datacenter) do
+    desc "The name of the datacenter hosting the target VM"
+    newvalues(/\w/)
+  end
+
+  newparam(:datastore) do
+    desc "The target datastore used for creation of the virtual disk file"
+  end
+
+  newparam(:thin_provisioned) do
+    desc "Flag to indicate to the underlying filesystem, whether the virtual disk backing file should be allocated lazily (using thin provisioning)"
+    newvalues(:true, :false)
+    defaultto(:true)
+  end
+
+  newparam(:eager_scrub) do
+    desc "Flag to indicate to the underlying filesystem whether the virtual disk backing file should be scrubbed completely at this time. If this flag is unset or set to false when creating a new disk, the disk scrubbing policy will be decided by the filesystem."
+    newvalues(:true, :false)
+  end
+
+  newparam(:remove_disk) do
+    desc "If attempting to destroy the resource, this will determine if the backing file is deleted from the datastore"
+    newvalues(:true, :false)
+    defaultto(:false)
+  end
+
+  #### create resource properties from mapper ####
+  # besides the map name, this section should remain the same between types created using vmware mapper
+  map = PuppetX::VMware::Mapper.new_map('VirtualDiskMap')
+  map.leaf_list.each do |leaf|
+    option = {}
+    if type_hash = leaf.olio[t = Puppet::Property::VMware_Array]
+      option.update(
+        :array_matching => :all,
+        :parent => t
+      )
+    elsif type_hash = leaf.olio[t = Puppet::Property::VMware_Array_Hash]
+      option.update(
+        :parent => t
+      )
+    end
+    option.update(type_hash[:property_option]) if
+        type_hash && type_hash[:property_option]
+
+    newproperty(leaf.prop_name, option) do
+      desc(leaf.desc) if leaf.desc
+      newvalues(*leaf.valid_enum) if leaf.valid_enum
+      munge {|val| leaf.munge.call(val)} if leaf.munge
+      validate {|val| leaf.validate.call(val)} if leaf.validate
+      eval <<-EOS
+        def change_to_s(is,should)
+          "[#{leaf.full_name}] changed \#{is_to_s(is).inspect} to \#{should_to_s(should).inspect}"
+        end
+      EOS
+    end
+  end
+end

--- a/lib/puppet/type/vm_hardware.rb
+++ b/lib/puppet/type/vm_hardware.rb
@@ -1,0 +1,52 @@
+# Copyright (C) 2013 VMware, Inc.
+require 'pathname'
+module_lib    = Pathname.new(__FILE__).parent.parent.parent
+vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
+require File.join vmware_module.path, 'lib/puppet/property/vmware'
+require File.join module_lib, 'puppet_x/vmware/mapper'
+
+Puppet::Type.newtype(:vm_hardware) do
+  @doc = "Manage a vCenter VM's virtual hardware settings. See http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.VirtualHardware.html for class details"
+
+  #### create parameters ####
+  # the parameters are specific data points needed to set the properties pulled in by mapper and may change between types 
+  newparam(:vm_name, :namevar => true) do
+    desc "The name of the target VM"
+  end
+
+  newparam(:datacenter) do
+    desc "The name of the datacenter hosting the target VM"
+    newvalues(/\w/)
+  end
+
+  #### create resource properties from mapper ####
+  # besides the map name, this section should remain the same between types created using vmware mapper
+  map = PuppetX::VMware::Mapper.new_map('VirtualHardwareMap')
+  map.leaf_list.each do |leaf|
+    option = {}
+    if type_hash = leaf.olio[t = Puppet::Property::VMware_Array]
+      option.update(
+        :array_matching => :all,
+        :parent => t
+      )
+    elsif type_hash = leaf.olio[t = Puppet::Property::VMware_Array_Hash]
+      option.update(
+        :parent => t
+      )
+    end
+    option.update(type_hash[:property_option]) if
+        type_hash && type_hash[:property_option]
+
+    newproperty(leaf.prop_name, option) do
+      desc(leaf.desc) if leaf.desc
+      newvalues(*leaf.valid_enum) if leaf.valid_enum
+      munge {|val| leaf.munge.call(val)} if leaf.munge
+      validate {|val| leaf.validate.call(val)} if leaf.validate
+      eval <<-EOS
+        def change_to_s(is,should)
+          "[#{leaf.full_name}] changed \#{is_to_s(is).inspect} to \#{should_to_s(should).inspect}"
+        end
+      EOS
+    end
+  end
+end

--- a/lib/puppet/type/vm_nic.rb
+++ b/lib/puppet/type/vm_nic.rb
@@ -1,0 +1,81 @@
+# Copyright (C) 2015 VMware, Inc.
+require 'pathname'
+module_lib    = Pathname.new(__FILE__).parent.parent.parent
+vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
+require File.join vmware_module.path, 'lib/puppet/property/vmware'
+require File.join module_lib, 'puppet_x/vmware/mapper'
+
+Puppet::Type.newtype(:vm_nic) do
+  @doc = "Manage a vCenter VM's virtual network adapter settings. See http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.device.VirtualEthernetCard.html for class details"
+  
+  #### create parameters ####
+  # the parameters are specific data points needed to set the properties pulled in by mapper and may change between types 
+  ensurable do
+    newvalue(:present) do
+      provider.create
+    end
+
+    newvalue(:absent) do
+      provider.destroy
+    end
+
+    defaultto(:present)
+
+    def change_to_s(is, should)
+      if should == :present
+        provider.create_message
+      else
+        "removed"
+      end
+    end
+  end
+
+  newparam(:name) do
+    desc "The display label of the network card"
+  end
+
+  newparam(:vm_name) do
+    desc "The name of the target VM"
+  end
+
+  newparam(:datacenter) do
+    desc "The name of the datacenter hosting the target VM"
+    newvalues(/\w/)
+  end
+
+  newparam(:portgroup_type) do
+    desc "The type of portgroup to assign to"
+    newvalues(:standard, :distributed)
+  end
+
+  #### create resource properties from mapper ####
+  # besides the map name, this section should remain the same between types created using vmware mapper
+  map = PuppetX::VMware::Mapper.new_map('VirtualEthernetCardMap')
+  map.leaf_list.each do |leaf|
+    option = {}
+    if type_hash = leaf.olio[t = Puppet::Property::VMware_Array]
+      option.update(
+        :array_matching => :all,
+        :parent => t
+      )
+    elsif type_hash = leaf.olio[t = Puppet::Property::VMware_Array_Hash]
+      option.update(
+        :parent => t
+      )
+    end
+    option.update(type_hash[:property_option]) if
+        type_hash && type_hash[:property_option]
+
+    newproperty(leaf.prop_name, option) do
+      desc(leaf.desc) if leaf.desc
+      newvalues(*leaf.valid_enum) if leaf.valid_enum
+      munge {|val| leaf.munge.call(val)} if leaf.munge
+      validate {|val| leaf.validate.call(val)} if leaf.validate
+      eval <<-EOS
+        def change_to_s(is,should)
+          "[#{leaf.full_name}] changed \#{is_to_s(is).inspect} to \#{should_to_s(should).inspect}"
+        end
+      EOS
+    end
+  end
+end

--- a/lib/puppet_x/vmware/mapper/virtual_disk_map.rb
+++ b/lib/puppet_x/vmware/mapper/virtual_disk_map.rb
@@ -1,0 +1,65 @@
+# Copyright 2015 VMware, Inc.
+
+require 'set'
+
+module PuppetX::VMware::Mapper
+
+  class VirtualDiskMap < Map
+    def initialize
+      @initTree = {
+        Node => NodeData[
+          :node_type => 'VirtualDisk',
+        ],
+        :key           => LeafData[
+          :desc          => 'Only used internally when a update or removal to an existing monitor',
+        ],
+        :controllerKey => LeafData[
+          :desc          => 'Object key for the controller object for this device. This property contains the key property value of the controller device object.',
+          :prop_name     => 'controller'
+        ],
+        :capacityInKB => LeafData[
+          :desc       => 'Capacity of this virtual disk in bytes. Server will always populate this property. Clients must initialize it when creating a new non -RDM disk or in case they want to change the current capacity of an existing virtual disk, but can omit it otherwise.',
+          :prop_name  => 'capacity_in_kb',
+          :munge => PuppetX::VMware::Mapper::munge_to_i,
+        ],
+        :backing      => {
+          Node => NodeData[
+            :node_type => 'VirtualDeviceFileBackingInfo',
+          ],
+          :diskMode     => LeafData[
+            :desc       => 'The disk persistence mode.',
+            :valid_enum => [:persistent, :nonpersistent, :independent_persistent, :independent_nonpersistent],
+          ],
+          :writeThrough     => LeafData[
+            :desc           => 'lag to indicate whether writes should go directly to the file system or should be buffered.',
+            :valid_enum     => [:true, :false]
+          ],
+        },
+        :storageIOAllocation => {
+          Node => NodeData[
+            :node_type => 'StorageIOAllocationInfo',
+          ],
+          :limit => LeafData[
+            :desc  => 'The utilization of a virtual machine will not exceed this limit, even if there are available resources.',
+            :munge => PuppetX::VMware::Mapper::munge_to_i,
+          ],
+          :shares => {
+            Node => NodeData[
+              :node_type => 'SharesInfo',
+            ],
+            :level         => LeafData[
+              :desc => 'The allocation level. The level is a simplified view of shares. Levels map to a pre-determined set of numeric values for shares. If the shares value does not map to a predefined size, then the level is set as custom. ',
+	      :valid_enum => [:normal, :low, :high, :custom]
+            ],
+            :shares => LeafData[
+              :desc => 'The number of shares allocated. Used to determine resource allocation in case of resource contention. This value is only set if level is set to custom. If level is not set to custom, this value is ignored. Therefore, only shares with custom values can be compared.',
+              :munge         => PuppetX::VMware::Mapper::munge_to_i,
+            ],
+          },
+        },
+      }
+
+      super
+    end
+  end
+end

--- a/lib/puppet_x/vmware/mapper/virtual_ethernet_card_map.rb
+++ b/lib/puppet_x/vmware/mapper/virtual_ethernet_card_map.rb
@@ -1,0 +1,74 @@
+# Copyright 2015 VMware, Inc.
+
+require 'set'
+
+module PuppetX::VMware::Mapper
+
+  class VirtualEthernetCardMap < Map
+    def initialize
+      @initTree = {
+        Node => NodeData[
+          :node_type => 'VirtualEthernetCard',
+        ],
+        :type               => LeafData[
+          :desc             => 'Virtual Ethernet Card Type',
+          :valid_enum       => [:e1000, :e1000e, :vmxnet2, :vmxnet3]
+        ],
+        :portgroup          => LeafData[
+          :desc             => "The name of the portgroup this adapter is connected on"
+        ],
+        :addressType        => LeafData[
+          :desc             => 'MAC address type',
+          :valid_enum       => [:manual, :generated, :assigned]
+        ],
+        :macAddress         => LeafData[
+          :desc             => 'MAC address assigned to the virtual network adapter.'
+        ],
+        :wakeOnLanEnabled   => LeafData[
+          :desc             => 'Indicates whether wake-on-LAN is enabled on this virtual network adapter.',
+          :valid_enum       => [:true, :false]
+        ],
+        :unitNumber         => LeafData[
+          :desc             => 'The unit number of this device on its controller'
+        ],
+        :controllerKey      => LeafData[
+          :desc             => 'Object key for the controller object for this device.'
+        ],
+        :key                => LeafData[
+          :desc             => 'Used Internally. A unique key that distinguishes this device from other devices in the same virtual machine.'
+        ],
+        :deviceInfo         => {
+          Node => NodeData[
+            :node_type      => 'Description',
+          ],
+          :summary          => LeafData[
+            :desc           => 'Summary description'
+          ],
+        },
+        :connectable        => {
+          Node => NodeData[
+            :node_type      => 'VirtualDeviceConnectInfo'
+          ],
+          :allowGuestControl => LeafData[
+            :desc            => 'Enables guest control over whether the connectable device is connected.',
+            :valid_enum      => [:true, :false]
+          ],
+          :connected         => LeafData[
+            :desc            => 'Indicates whether the device is currently connected. Valid only while the virtual machine is running.',
+            :valid_enum      => [:true, :false]
+          ],
+          :startConnected    => LeafData[
+            :desc            => 'Specifies whether or not to connect the device when the virtual machine starts.',
+            :valid_enum      => [:true, :false]
+          ], 
+          :status            => LeafData[
+            :desc            => 'Indicates the current status of the connectable device. Valid only while the virtual machine is running.',
+            :valid_enum      => [:ok, :recoverableError, :unrecoverableError, :untried]
+          ],
+        },
+      }
+
+      super
+    end
+  end
+end

--- a/lib/puppet_x/vmware/mapper/virtual_hardware_map.rb
+++ b/lib/puppet_x/vmware/mapper/virtual_hardware_map.rb
@@ -1,0 +1,44 @@
+# Copyright 2015 VMware, Inc.
+
+require 'set'
+
+module PuppetX::VMware::Mapper
+
+  class VirtualHardwareMap < Map
+    def initialize
+      @initTree = {
+        Node => NodeData[
+          :node_type => 'VirtualHardware',
+        ],
+        :memoryMB => LeafData[
+          :desc     => "The memory size to assign to the target VM",
+          :validate => PuppetX::VMware::Mapper::validate_i_ge(0),
+          :munge    => PuppetX::VMware::Mapper::munge_to_i,
+        ],
+        :numCoresPerSocket => LeafData[
+          :desc     => "The number of cores per CPU socket on the target VM",
+          :validate => PuppetX::VMware::Mapper::validate_i_ge(1),
+          :munge    => PuppetX::VMware::Mapper::munge_to_i,
+        ],
+        :numCPUs => LeafData[
+          :desc        => "The total number of vCPUs on the target VM. numCPUs % numCoresPerSocket should always equal 0",
+          :validate    => PuppetX::VMware::Mapper::validate_i_ge(1),
+          :munge       => PuppetX::VMware::Mapper::munge_to_i,
+          :path_is_now => [:numCPU],
+        ],
+        :virtualICH7MPresent => LeafData[
+          :prop_name  => 'virtual_ich7m_present',
+          :desc       => "Does this virtual machine have Virtual Intel I/O Controller Hub 7",
+          :valid_enum => [:true, :false],
+        ],
+        :virtualSMCPresent => LeafData[
+          :prop_name  => 'virtual_smc_present',
+          :desc       => "Does this virtual machine have System Management Controller",
+          :valid_enum => [:true, :false],
+        ],
+      }
+
+      super
+    end
+  end
+end

--- a/manifests/vm_config.pp
+++ b/manifests/vm_config.pp
@@ -1,0 +1,66 @@
+class vcenter::vm_config (
+  $vc_username,
+  $vc_password,
+  $vc_hostname,
+  $vm_name,
+  $datacenter,
+  $transport_options       = {},
+  $vm_nics                 = {},
+  $vm_harddisks            = {},
+  $vapp_properties         = {},
+  $num_cpus                = undef,
+  $num_cores               = undef,
+  $memory                  = undef,
+  $ich7m                   = undef,
+  $smc                     = undef,
+  $power_state             = 'poweredOn',
+) {
+
+  $default_transport_options = {
+    'rev' => '5.5',
+    'insecure' => true
+  }
+  $merged_options = merge($default_transport_options, $transport_options)
+  transport { "vcenter":
+    username => $vc_username,
+    password => $vc_password,
+    server   => $vc_hostname,
+    options  => $merged_options,
+  }
+
+  $resource_defaults = {
+    vm_name    => $vm_name,
+    datacenter => $datacenter,
+    transport  => Transport["vcenter"],
+    before     => Vc_vm[$vm_name]
+  }
+
+  if !empty($vapp_properties) {
+    create_resources(vm_vapp_property, $vapp_properties, $resource_defaults)
+  }
+
+  if !empty($vm_nics) {
+    create_resources(vm_nic, $vm_nics, $resource_defaults)
+  }
+  
+  if !empty($vm_harddisks) {
+    create_resources(vm_harddisk, $vm_harddisks, $resource_defaults)
+  }
+  
+  vm_hardware { $vm_name :
+    datacenter             => $datacenter,
+    num_cpus               => $num_cpus,
+    num_cores_per_socket   => $num_cores,
+    memory_mb              => $memory,
+    virtual_ich7m_present  => $ich7m,
+    virtual_smc_present    => $smc,
+    transport              => Transport['vcenter'],
+    before                 => Vc_vm[$vm_name]
+  }
+
+  vc_vm { $vm_name :
+    power_state       => $power_state,
+    datacenter_name   => $datacenter,
+    transport         => Transport["vcenter"],
+  }
+}

--- a/tests/sample_data.pp
+++ b/tests/sample_data.pp
@@ -85,3 +85,30 @@ $vpx_settings = {
   'event.maxAgeEnabled' => false,
   'event.maxAge'        => l4,
 }
+
+# Sample data for vm_hardware, vm_nic and vm_harddisk
+$vmname = 'vm1'
+$datacenter = 'testdc1'
+
+###  vm_hardware
+$num_cpus   = '4'
+$num_cores  = 1
+$memory     = 2048
+$ich7m      = false
+$smc        = false
+
+###  vm_virtualdisk
+$hdd             = 'Hard disk 2'
+$shareLevel      = 'high'
+$capacity        = 8388608
+$diskMode        = 'persistent'
+$controller      = "SCSI controller 0"
+
+###  vm_vmxnet3
+$vnic            = 'Network adapter 2'
+$nic_type        = 'e1000e'
+$portgroup       = 'VM Network'
+$portgroup_type  = 'standard'
+$startConnected  = true
+$guestControlled = true
+$wakeOnLan       = false

--- a/tests/vm_config.pp
+++ b/tests/vm_config.pp
@@ -1,0 +1,34 @@
+class { 'vcenter::vm_config' :
+  vc_username      => 'administrator@vsphere.local',
+  vc_password      => 'vmware',
+  vc_hostname      => '192.168.1.100',
+  vm_name          => 'vm1',
+  datacenter       => 'dc1',
+  vm_nics          => { 
+    'Network adapter 1' => {
+       ensure           => present,
+       'type'           => 'vmxnet3',
+       'portgroup'      => 'VM Network',
+       'portgroup_type' => 'standard',
+       before           => Vm_nic['Network adapter 2']
+    }, 
+    'Network adapter 2' => {
+      ensure           => present,
+      'type'           => 'e1000e',
+      'portgroup'      => 'dvpg1',
+      'portgroup_type' => 'distributed',
+    },
+  },
+  vm_harddisks     => {
+    'Hard disk 2' => {
+      'datastore'      => 'datastore1',
+      'controller'     => 'SCSI controller 0',
+      'level'          => 'normal',
+      'capacity_in_kb' => 10485760,
+      'disk_mode'      => 'persistent'
+    }
+  },
+  num_cpus          => 4,
+  num_cores         => 2,
+  memory            => 4096,
+}

--- a/tests/vm_harddisk.pp
+++ b/tests/vm_harddisk.pp
@@ -1,0 +1,21 @@
+import 'data.pp'
+
+transport { 'vcenter':
+  username => $vcenter['username'],
+  password => $vcenter['password'],
+  server   => $vcenter['server'],
+  options  => $vcenter['options'],
+}
+
+vm_harddisk { $hdd :
+  ensure         => present,  
+  datacenter     => $datacenter,
+  vm_name        => $vmname,
+  datastore      => $datastore,
+  controller     => $controller,
+  level          => $shareLevel,
+  capacity_in_kb => $capacity,
+  disk_mode      => $diskMode,
+  transport      => Transport['vcenter'],
+}
+

--- a/tests/vm_hardware.pp
+++ b/tests/vm_hardware.pp
@@ -1,0 +1,18 @@
+import 'data.pp'
+
+transport { 'vcenter':
+  username => $vcenter['username'],
+  password => $vcenter['password'],
+  server   => $vcenter['server'],
+  options  => $vcenter['options'],
+}
+
+vm_hardware { $vmname :
+  datacenter             => $datacenter,
+  num_cpus               => $num_cpus,
+  num_cores_per_socket   => $num_cores,
+  memory_mb              => $memory,
+  virtual_ich7m_present  => $ich7m,
+  virtual_smc_present    => $smc,
+  transport              => Transport['vcenter'],
+} 

--- a/tests/vm_nic.pp
+++ b/tests/vm_nic.pp
@@ -1,0 +1,25 @@
+import 'data.pp'
+
+transport { 'vcenter':
+  username => $vcenter['username'],
+  password => $vcenter['password'],
+  server   => $vcenter['server'],
+  options  => $vcenter['options'],
+}
+
+vm_nic { $vnic :
+  ensure               => present,  
+  vm_name              => $vmname,
+  datacenter           => $datacenter,
+  type                 => $nic_type,
+  portgroup            => $portgroup,
+  portgroup_type       => $portgroup_type,
+#  start_connected      => $startConnected,
+#  wake_on_lan_enabled  => $wakeOnLan,
+#  status               => 'ok',
+#  allow_guest_control  => $guestControlled,
+#  connected            => 'true',
+  transport            => Transport['vcenter'],
+}
+
+#create_resources(vm_vmxnet3, $nics, $nic_defaults)

--- a/tests/vm_nic.pp
+++ b/tests/vm_nic.pp
@@ -16,9 +16,7 @@ vm_nic { $vnic :
   portgroup_type       => $portgroup_type,
 #  start_connected      => $startConnected,
 #  wake_on_lan_enabled  => $wakeOnLan,
-#  status               => 'ok',
 #  allow_guest_control  => $guestControlled,
-#  connected            => 'true',
   transport            => Transport['vcenter'],
 }
 


### PR DESCRIPTION
--Created new type vm_hardware to configure basic hardware configs
--Created new type vm_nic to create, modify and delete virtual network adapters
--Moved method 'findvm' out of individual providers and into Puppet::Provider::Vcenter
--Created new type vm_harddisk to manage hard disks attached to VM
--Created class vm_config to allow a generic class for configuring a VM