### PR TITLE
Expand vc_dvswitch_pool to support creating user defined network reso…

### DIFF
--- a/lib/puppet/type/vc_dvswitch_pool.rb
+++ b/lib/puppet/type/vc_dvswitch_pool.rb
@@ -3,6 +3,15 @@ Puppet::Type.newtype(:vc_dvswitch_pool) do
   @doc = "Manages vCenter Distributed Virtual Switch "\
          "Network Resource Pool Management"
 
+  ensurable do
+    newvalue(:present) do
+      provider.create
+    end
+    newvalue(:absent) do
+      provider.destroy
+    end
+  end
+
   newparam(:name, :namevar => true) do
     desc "{path to dvswitch}:{network resource pool key}"
 
@@ -26,12 +35,16 @@ Puppet::Type.newtype(:vc_dvswitch_pool) do
   newparam(:dvswitch_name) do
   end
 
-  newproperty(:key) do
+  newparam(:key) do
     desc "pool identifier"
   end
 
+  newproperty(:description) do
+    desc "A string describing the network resource pool"
+  end
+
   newproperty(:limit) do
-    desc ""
+    desc "Maximum allowed usage for network clients belonging to this resource pool per host. To set to Unlimited set this to -1"
   end
 
   newproperty(:priority_tag) do


### PR DESCRIPTION
…urce pools

--Made type ensurable
--Added create, exists? and destroy methods
--Moved key to parameter instead of propert since the key cannot be changed after creation
--Added property 'description' to allow managing the user defined network resource pool descriptions
--Enhanced setting network resource pool shares based off the level and networkResourcePoolHighShareValue based off https://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.SharesInfo.Level.html