### PR TITLE
Provide a more centralized way of requiring vmware_lib

### DIFF
--- a/lib/puppet/provider/esx_iscsi_targets/default.rb
+++ b/lib/puppet/provider/esx_iscsi_targets/default.rb
@@ -2,11 +2,11 @@
 require 'set'
 
 require 'pathname'
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
+
 module_lib = Pathname.new(__FILE__).parent.parent.parent.parent
 require File.join module_lib, 'puppet/provider/vcenter'
 require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
 
 Puppet::Type.type(:esx_iscsi_targets).provide(:esx_iscsi_targets, :parent => Puppet::Provider::Vcenter) do
   @doc = "Manages iSCSI targets."

--- a/lib/puppet/provider/esx_vmknic/default.rb
+++ b/lib/puppet/provider/esx_vmknic/default.rb
@@ -2,11 +2,11 @@
 require 'set'
 
 require 'pathname' # WORK_AROUND #14073 and #7788
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
 module_lib = Pathname.new(__FILE__).parent.parent.parent.parent
+
 require File.join module_lib, 'puppet/provider/vcenter'
 require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
 
 Puppet::Type.type(:esx_vmknic).provide(:esx_vmknic, :parent => Puppet::Provider::Vcenter) do
   @doc = "Manages ESXi vmknics."

--- a/lib/puppet/provider/esx_vmknic_type/default.rb
+++ b/lib/puppet/provider/esx_vmknic_type/default.rb
@@ -1,11 +1,11 @@
 # Copyright (C) 2013 VMware, Inc.
 
 require 'pathname' # WORK_AROUND #14073 and #7788
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
 module_lib = Pathname.new(__FILE__).parent.parent.parent.parent
+
 require File.join module_lib, 'puppet/provider/vcenter'
 require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
 
 Puppet::Type.type(:esx_vmknic_type).provide(:esx_vmknic_type, :parent => Puppet::Provider::Vcenter) do
   @doc = "Manages ESXi vmknic types - "\

--- a/lib/puppet/provider/vc_affinity/default.rb
+++ b/lib/puppet/provider/vc_affinity/default.rb
@@ -2,10 +2,10 @@
 require 'set'
 require 'pathname' # WORK_AROUND #14073 and #7788
 
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
 module_lib = Pathname.new(__FILE__).parent.parent.parent.parent
+
 require File.join module_lib, 'puppet/provider/vcenter'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
 
 Puppet::Type.type(:vc_affinity).provide(:vc_affinity, :parent => Puppet::Provider::Vcenter) do
   @doc = "Manages vCenter cluster's settings for VM affinity and anti-affinity rules."

--- a/lib/puppet/provider/vc_cluster_ha/default.rb
+++ b/lib/puppet/provider/vc_cluster_ha/default.rb
@@ -3,11 +3,10 @@ require 'set'
 
 require 'pathname' # WORK_AROUND #14073 and #7788
 
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
 module_lib = Pathname.new(__FILE__).parent.parent.parent.parent
 require File.join module_lib, 'puppet/provider/vcenter'
 require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
 
 Puppet::Type.type(:vc_cluster_ha).provide(:vc_cluster_ha, :parent => Puppet::Provider::Vcenter) do
   @doc = "Manages vCenter cluster's settings for HA (High Availability)."

--- a/lib/puppet/provider/vc_dvportgroup/default.rb
+++ b/lib/puppet/provider/vc_dvportgroup/default.rb
@@ -2,11 +2,10 @@
 require 'set'
 
 require 'pathname' # WORK_AROUND #14073 and #7788
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
 module_lib = Pathname.new(__FILE__).parent.parent.parent.parent
 require File.join module_lib, 'puppet/provider/vcenter'
 require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
 
 Puppet::Type.type(:vc_dvportgroup).provide(:vc_dvportgroup, :parent => Puppet::Provider::Vcenter) do
   @doc = "Manages vCenter Distributed Virtual Portgroup"

--- a/lib/puppet/provider/vc_dvswitch/default.rb
+++ b/lib/puppet/provider/vc_dvswitch/default.rb
@@ -2,12 +2,11 @@
 require 'set'
 
 require 'pathname' # WORK_AROUND #14073 and #7788
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
-require File.join vmware_module.path, 'lib/puppet/property/vmware'
 module_lib = Pathname.new(__FILE__).parent.parent.parent.parent
 require File.join module_lib, 'puppet/provider/vcenter'
 require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet/property/vmware'
 
 Puppet::Type.type(:vc_dvswitch).provide(:vc_dvswitch, :parent => Puppet::Provider::Vcenter) do
   @doc = "Manages vCenter Distributed Virtual Switch"

--- a/lib/puppet/provider/vc_dvswitch_migrate/default.rb
+++ b/lib/puppet/provider/vc_dvswitch_migrate/default.rb
@@ -1,10 +1,10 @@
 # Copyright (C) 2013 VMware, Inc.
 
 require 'pathname' # WORK_AROUND #14073 and #7788
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
 module_lib = Pathname.new(__FILE__).parent.parent.parent.parent
+
 require File.join module_lib, 'puppet/provider/vcenter'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
 
 Puppet::Type.type(:vc_dvswitch_migrate).provide( :vc_dvswitch_migrate, 
                      :parent => Puppet::Provider::Vcenter) do

--- a/lib/puppet/provider/vc_dvswitch_nioc/default.rb
+++ b/lib/puppet/provider/vc_dvswitch_nioc/default.rb
@@ -1,10 +1,10 @@
 # Copyright (C) 2013 VMware, Inc.
 
 require 'pathname' # WORK_AROUND #14073 and #7788
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
+
 module_lib = Pathname.new(__FILE__).parent.parent.parent.parent
 require File.join module_lib, 'puppet/provider/vcenter'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
 
 Puppet::Type.type(:vc_dvswitch_nioc).provide( :vc_dvswitch_nioc, 
                      :parent => Puppet::Provider::Vcenter) do

--- a/lib/puppet/provider/vc_host_group/default.rb
+++ b/lib/puppet/provider/vc_host_group/default.rb
@@ -2,10 +2,9 @@
 require 'set'
 require 'pathname'
 
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
 module_lib = Pathname.new(__FILE__).parent.parent.parent.parent
 require File.join module_lib, 'puppet/provider/vcenter'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
 
 Puppet::Type.type(:vc_host_group).provide(:vc_host_group, :parent => Puppet::Provider::Vcenter) do
   @doc = "Manages vCenter cluster's settings for Host Groups used for VM-Host rules. http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.cluster.HostGroup.html"

--- a/lib/puppet/provider/vc_ip_pool/default.rb
+++ b/lib/puppet/provider/vc_ip_pool/default.rb
@@ -2,11 +2,8 @@
 require 'set'
 
 require 'pathname'
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
 module_lib = Pathname.new(__FILE__).parent.parent.parent.parent
-Puppet.debug "module_lib = #{module_lib.inspect}"
-Puppet.debug "File.join module_lib, 'puppet/provider/vcenter'  = #{File.join module_lib, 'puppet/provider/vcenter'}"
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
 require File.join module_lib, 'puppet/provider/vcenter'
 require File.join module_lib, 'puppet_x/vmware/mapper'
 

--- a/lib/puppet/provider/vc_vm_group/default.rb
+++ b/lib/puppet/provider/vc_vm_group/default.rb
@@ -2,10 +2,9 @@
 require 'set'
 require 'pathname'
 
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
 module_lib = Pathname.new(__FILE__).parent.parent.parent.parent
 require File.join module_lib, 'puppet/provider/vcenter'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
 
 Puppet::Type.type(:vc_vm_group).provide(:vc_vm_group, :parent => Puppet::Provider::Vcenter) do
   @doc = "Manages vCenter cluster's settings for VM Groups used for VM-Host rules. http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.cluster.VmGroup.html"

--- a/lib/puppet/provider/vc_vm_host_rule/default.rb
+++ b/lib/puppet/provider/vc_vm_host_rule/default.rb
@@ -2,13 +2,10 @@
 require 'set'
 
 require 'pathname'
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
 module_lib = Pathname.new(__FILE__).parent.parent.parent.parent
-Puppet.debug "module_lib = #{module_lib.inspect}"
-Puppet.debug "File.join module_lib, 'puppet/provider/vcenter'  = #{File.join module_lib, 'puppet/provider/vcenter'}"
 require File.join module_lib, 'puppet/provider/vcenter'
 require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
 
 Puppet::Type.type(:vc_vm_host_rule).provide(:vc_vm_host_rule, :parent => Puppet::Provider::Vcenter) do
   @doc = "Manages vCenter cluster's settings for VM-Host rules. http://pubs.vmware.com/vsphere-55/index.jsp?topic=%2Fcom.vmware.wssdk.apiref.doc%2Fvim.cluster.VmHostRuleInfo.html"

--- a/lib/puppet/provider/vcenter.rb
+++ b/lib/puppet/provider/vcenter.rb
@@ -1,28 +1,12 @@
 # Copyright (C) 2013 VMware, Inc.
-begin
-  require 'puppet_x/puppetlabs/transport'
-rescue LoadError => e
-  require 'pathname' # WORK_AROUND #14073 and #7788
-  vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-  require File.join vmware_module.path, 'lib/puppet_x/puppetlabs/transport'
-end
+#
 
-begin
-  require 'puppet_x/puppetlabs/transport/vsphere'
-rescue LoadError => e 
-  require 'pathname' # WORK_AROUND #14073 and #7788
-  module_lib = Pathname.new(__FILE__).parent.parent.parent
-  require File.join module_lib, 'puppet_x/puppetlabs/transport/vsphere'
-end
+module_lib = Pathname.new(__FILE__).parent.parent.parent
 
-begin
-  require 'puppet_x/vmware/util'
-rescue LoadError => e 
-  require 'pathname' # WORK_AROUND #14073 and #7788
-  module_lib = Pathname.new(__FILE__).parent.parent.parent
-  vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-  require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
-end
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/puppetlabs/transport'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/puppetlabs/transport/vsphere'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
+
 
 class Puppet::Provider::Vcenter <  Puppet::Provider
   confine :feature => :vsphere

--- a/lib/puppet/provider/vm_harddisk/default.rb
+++ b/lib/puppet/provider/vm_harddisk/default.rb
@@ -1,10 +1,10 @@
 # Copyright (C) 2014 VMware, Inc.
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
-require File.join vmware_module.path, 'lib/puppet/property/vmware'
 module_lib    = Pathname.new(__FILE__).parent.parent.parent.parent
+
 require File.join module_lib, 'puppet_x/vmware/mapper'
 require File.join module_lib, 'puppet/provider/vcenter'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet/property/vmware'
 
 Puppet::Type.type(:vm_harddisk).provide(:vm_harddisk, :parent => Puppet::Provider::Vcenter) do
   @doc = "Manage a vCenter VM's virtual disk settings. See http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.device.VirtualDisk.html for class details"

--- a/lib/puppet/provider/vm_hardware/default.rb
+++ b/lib/puppet/provider/vm_hardware/default.rb
@@ -1,10 +1,10 @@
 # Copyright (C) 2014 VMware, Inc.
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
-require File.join vmware_module.path, 'lib/puppet/property/vmware'
+#
 module_lib    = Pathname.new(__FILE__).parent.parent.parent.parent
 require File.join module_lib, 'puppet_x/vmware/mapper'
 require File.join module_lib, 'puppet/provider/vcenter'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet/property/vmware'
 
 Puppet::Type.type(:vm_hardware).provide(:vm_hardware, :parent => Puppet::Provider::Vcenter) do
   @doc = "Manage a vCenter VM's virtual hardware settings. See http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.VirtualHardware.html for class details"

--- a/lib/puppet/provider/vm_nic/default.rb
+++ b/lib/puppet/provider/vm_nic/default.rb
@@ -1,10 +1,10 @@
 # Copyright (C) 2014 VMware, Inc.
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
-require File.join vmware_module.path, 'lib/puppet/property/vmware'
 module_lib    = Pathname.new(__FILE__).parent.parent.parent.parent
+
 require File.join module_lib, 'puppet_x/vmware/mapper'
 require File.join module_lib, 'puppet/provider/vcenter'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet/property/vmware'
 
 Puppet::Type.type(:vm_nic).provide(:vm_nic, :parent => Puppet::Provider::Vcenter) do
   @doc = "Manage a vCenter VM's virtual network adapter settings. See http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.device.VirtualEthernetCard.html for class details"

--- a/lib/puppet/type/esx_iscsi_targets.rb
+++ b/lib/puppet/type/esx_iscsi_targets.rb
@@ -1,12 +1,11 @@
 # Copyright (C) 2013 VMware, Inc.
-require 'pathname' # WORK_AROUND #14073 and #7788
+require 'pathname'
 module_lib = Pathname.new(__FILE__).parent.parent.parent
 
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
 require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet/property/vmware'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
 
-require File.join vmware_module.path, 'lib/puppet/property/vmware'
 
 Puppet::Type.newtype(:esx_iscsi_targets) do
   @doc = "Manage iSCSI targets."

--- a/lib/puppet/type/esx_vmknic.rb
+++ b/lib/puppet/type/esx_vmknic.rb
@@ -1,12 +1,10 @@
 # Copyright (C) 2013 VMware, Inc.
-require 'pathname' # WORK_AROUND #14073 and #7788
+require 'pathname'
 module_lib = Pathname.new(__FILE__).parent.parent.parent
-
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
 require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet/property/vmware'
 
-require File.join vmware_module.path, 'lib/puppet/property/vmware'
 
 Puppet::Type.newtype(:esx_vmknic) do
   @doc = "Manages Virtual Adapters"

--- a/lib/puppet/type/esx_vmknic_type.rb
+++ b/lib/puppet/type/esx_vmknic_type.rb
@@ -1,11 +1,11 @@
 # Copyright (C) 2013 VMware, Inc.
 
-require 'pathname' # WORK_AROUND #14073 and #7788
+require 'pathname'
 module_lib = Pathname.new(__FILE__).parent.parent.parent
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
+
 require File.join module_lib, 'puppet_x/vmware/mapper'
-require File.join vmware_module.path, 'lib/puppet/property/vmware'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet/property/vmware'
 
 Puppet::Type.newtype(:esx_vmknic_type) do
   @doc = "Manages Virtual Adapters"

--- a/lib/puppet/type/vc_cluster_ha.rb
+++ b/lib/puppet/type/vc_cluster_ha.rb
@@ -1,12 +1,11 @@
 # Copyright (C) 2013 VMware, Inc.
-require 'pathname' # WORK_AROUND #14073 and #7788
+require 'pathname'
 module_lib = Pathname.new(__FILE__).parent.parent.parent
 
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
 require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet/property/vmware'
 
-require File.join vmware_module.path, 'lib/puppet/property/vmware'
 
 Puppet::Type.newtype(:vc_cluster_ha) do
   @doc = "Manages vCenter cluster's settings for HA (High Availability)."

--- a/lib/puppet/type/vc_dvportgroup.rb
+++ b/lib/puppet/type/vc_dvportgroup.rb
@@ -1,12 +1,10 @@
 # Copyright (C) 2013 VMware, Inc.
-require 'pathname' # WORK_AROUND #14073 and #7788
+require 'pathname'
 module_lib = Pathname.new(__FILE__).parent.parent.parent
 
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
 require File.join module_lib, 'puppet_x/vmware/mapper'
-
-require File.join vmware_module.path, 'lib/puppet/property/vmware'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet/property/vmware'
 
 Puppet::Type.newtype(:vc_dvportgroup) do
   @doc = "Manages vCenter Distributed Virtual Portgroup"

--- a/lib/puppet/type/vc_dvswitch.rb
+++ b/lib/puppet/type/vc_dvswitch.rb
@@ -1,12 +1,10 @@
 # Copyright (C) 2013 VMware, Inc.
-require 'pathname' # WORK_AROUND #14073 and #7788
+require 'pathname' 
 module_lib = Pathname.new(__FILE__).parent.parent.parent
 
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
 require File.join module_lib, 'puppet_x/vmware/mapper'
-
-require File.join vmware_module.path, 'lib/puppet/property/vmware'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet/property/vmware'
 
 Puppet::Type.newtype(:vc_dvswitch) do
   @doc = "Manages vCenter Distributed Virtual Switch"

--- a/lib/puppet/type/vc_dvswitch_migrate.rb
+++ b/lib/puppet/type/vc_dvswitch_migrate.rb
@@ -1,8 +1,9 @@
 # Copyright (C) 2013 VMware, Inc.
 
 require 'pathname' # WORK_AROUND #14073 and #7788
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
+module_lib = Pathname.new(__FILE__).parent.parent.parent
+
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
 
 Puppet::Type.newtype(:vc_dvswitch_migrate) do
   @doc = "Manages Distributed Virtual Switch migration on an ESXi host"\

--- a/lib/puppet/type/vc_dvswitch_nioc.rb
+++ b/lib/puppet/type/vc_dvswitch_nioc.rb
@@ -1,8 +1,8 @@
 # Copyright (C) 2013 VMware, Inc.
 
 require 'pathname' # WORK_AROUND #14073 and #7788
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
+module_lib = Pathname.new(__FILE__).parent.parent.parent
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
 
 Puppet::Type.newtype(:vc_dvswitch_nioc) do
   @doc = "Manages vCenter Distributed Virtual Switch "\

--- a/lib/puppet/type/vc_ip_pool.rb
+++ b/lib/puppet/type/vc_ip_pool.rb
@@ -2,10 +2,9 @@
 require 'pathname'
 module_lib = Pathname.new(__FILE__).parent.parent.parent
 
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
-require File.join vmware_module.path, 'lib/puppet/property/vmware'
 require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet/property/vmware'
 
 Puppet::Type.newtype(:vc_ip_pool) do
   @doc = "Manage vCenter IpPools. http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.vApp.IpPool.html"

--- a/lib/puppet/type/vc_vm.rb
+++ b/lib/puppet/type/vc_vm.rb
@@ -1,7 +1,6 @@
 # Copyright (C) 2013 VMware, Inc.
-require 'pathname'
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet/property/vmware'
+
+require File.dirname(__FILE__) + "/../../puppet_x/vmware/vmware_lib/puppet/property/vmware"
 
 Puppet::Type.newtype(:vc_vm) do
   @doc = "Manage vCenter VMs. Warning, this type / provider is currently experimental"

--- a/lib/puppet/type/vc_vm.rb
+++ b/lib/puppet/type/vc_vm.rb
@@ -1,6 +1,11 @@
 # Copyright (C) 2013 VMware, Inc.
+#
 
-require File.dirname(__FILE__) + "/../../puppet_x/vmware/vmware_lib/puppet/property/vmware"
+require 'pathname'
+
+module_lib    = Pathname.new(__FILE__).parent.parent.parent
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet/property/vmware'
+
 
 Puppet::Type.newtype(:vc_vm) do
   @doc = "Manage vCenter VMs. Warning, this type / provider is currently experimental"

--- a/lib/puppet/type/vc_vm_host_rule.rb
+++ b/lib/puppet/type/vc_vm_host_rule.rb
@@ -2,10 +2,9 @@
 require 'pathname'
 module_lib = Pathname.new(__FILE__).parent.parent.parent
 
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
-require File.join vmware_module.path, 'lib/puppet/property/vmware'
 require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet/property/vmware'
 
 Puppet::Type.newtype(:vc_vm_host_rule) do
   @doc = "Manages vCenter cluster's settings for VM-Host rules. http://pubs.vmware.com/vsphere-55/index.jsp?topic=%2Fcom.vmware.wssdk.apiref.doc%2Fvim.cluster.VmHostRuleInfo.html"

--- a/lib/puppet/type/vc_vpxsettings.rb
+++ b/lib/puppet/type/vc_vpxsettings.rb
@@ -1,7 +1,8 @@
 # Copyright (C) 2013 VMware, Inc.
 require 'pathname'
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet/property/vmware'
+
+module_lib = Pathname.new(__FILE__).parent.parent.parent
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet/property/vmware'
 
 Puppet::Type.newtype(:vc_vpxsettings) do
   @doc = "Manage vCenter vpxsettings ( event.maxAge, mail.smtp.server, etc )"

--- a/lib/puppet/type/vm_harddisk.rb
+++ b/lib/puppet/type/vm_harddisk.rb
@@ -1,9 +1,8 @@
 # Copyright (C) 2015 VMware, Inc.
 require 'pathname'
 module_lib    = Pathname.new(__FILE__).parent.parent.parent
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet/property/vmware'
 require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet/property/vmware'
 
 Puppet::Type.newtype(:vm_harddisk) do
   @doc = "Manage a vCenter VM's virtual disk settings. See http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.device.VirtualDisk.html for class details"

--- a/lib/puppet/type/vm_hardware.rb
+++ b/lib/puppet/type/vm_hardware.rb
@@ -1,9 +1,9 @@
 # Copyright (C) 2013 VMware, Inc.
 require 'pathname'
 module_lib    = Pathname.new(__FILE__).parent.parent.parent
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet/property/vmware'
+
 require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet/property/vmware'
 
 Puppet::Type.newtype(:vm_hardware) do
   @doc = "Manage a vCenter VM's virtual hardware settings. See http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.VirtualHardware.html for class details"

--- a/lib/puppet/type/vm_nic.rb
+++ b/lib/puppet/type/vm_nic.rb
@@ -1,9 +1,10 @@
 # Copyright (C) 2015 VMware, Inc.
 require 'pathname'
 module_lib    = Pathname.new(__FILE__).parent.parent.parent
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet/property/vmware'
+
 require File.join module_lib, 'puppet_x/vmware/mapper'
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet/property/vmware'
+
 
 Puppet::Type.newtype(:vm_nic) do
   @doc = "Manage a vCenter VM's virtual network adapter settings. See http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.device.VirtualEthernetCard.html for class details"

--- a/lib/puppet_x/vmware/mapper.rb
+++ b/lib/puppet_x/vmware/mapper.rb
@@ -1,10 +1,8 @@
 # Copyright (C) 2013 VMware, Inc.
 require 'pathname' # WORK_AROUND #14073 and #7788
 
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
-
 module_lib = Pathname.new(__FILE__).parent.parent.parent
+require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
 
 require 'set'
 

--- a/lib/puppet_x/vmware/vmware_lib/puppet/property/vmware.rb
+++ b/lib/puppet_x/vmware/vmware_lib/puppet/property/vmware.rb
@@ -1,0 +1,7 @@
+
+begin
+  require 'puppet/property/vmware'
+rescue LoadError => e
+  vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
+  require File.join vmware_module.path, 'lib/puppet/property/vmware'
+end

--- a/lib/puppet_x/vmware/vmware_lib/puppet/property/vmware.rb
+++ b/lib/puppet_x/vmware/vmware_lib/puppet/property/vmware.rb
@@ -1,4 +1,6 @@
-
+#
+# Wrapper to load the transport library from vmware_lib
+#
 begin
   require 'puppet/property/vmware'
 rescue LoadError => e

--- a/lib/puppet_x/vmware/vmware_lib/puppet_x/puppetlabs/transport.rb
+++ b/lib/puppet_x/vmware/vmware_lib/puppet_x/puppetlabs/transport.rb
@@ -1,0 +1,10 @@
+#
+# Wrapper to load the transport library from vmware_lib
+
+begin
+  require 'puppet_x/puppetlabs/transport'
+rescue LoadError => e
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
+  require File.join vmware_module.path, 'lib/puppet_x/puppetlabs/transport'
+end

--- a/lib/puppet_x/vmware/vmware_lib/puppet_x/puppetlabs/transport/vsphere.rb
+++ b/lib/puppet_x/vmware/vmware_lib/puppet_x/puppetlabs/transport/vsphere.rb
@@ -1,0 +1,9 @@
+
+
+begin
+  require 'puppet_x/puppetlabs/transport/vsphere'
+rescue LoadError => e
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  module_lib = Pathname.new(__FILE__).parent.parent.parent
+  require File.join module_lib, 'puppet_x/puppetlabs/transport/vsphere'
+end

--- a/lib/puppet_x/vmware/vmware_lib/puppet_x/puppetlabs/transport/vsphere.rb
+++ b/lib/puppet_x/vmware/vmware_lib/puppet_x/puppetlabs/transport/vsphere.rb
@@ -1,9 +1,0 @@
-
-
-begin
-  require 'puppet_x/puppetlabs/transport/vsphere'
-rescue LoadError => e
-  require 'pathname' # WORK_AROUND #14073 and #7788
-  module_lib = Pathname.new(__FILE__).parent.parent.parent
-  require File.join module_lib, 'puppet_x/puppetlabs/transport/vsphere'
-end

--- a/lib/puppet_x/vmware/vmware_lib/puppet_x/vmware/util.rb
+++ b/lib/puppet_x/vmware/vmware_lib/puppet_x/vmware/util.rb
@@ -1,0 +1,8 @@
+begin
+  require 'puppet_x/vmware/util'
+rescue LoadError => e
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  module_lib = Pathname.new(__FILE__).parent.parent.parent
+  vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
+  require File.join vmware_module.path, 'lib/puppet_x/vmware/util'
+end

--- a/lib/puppet_x/vmware/vmware_lib/puppet_x/vmware/util.rb
+++ b/lib/puppet_x/vmware/vmware_lib/puppet_x/vmware/util.rb
@@ -1,3 +1,7 @@
+#
+# Wrapper to load the transport library from vmware_lib
+#
+#
 begin
   require 'puppet_x/vmware/util'
 rescue LoadError => e


### PR DESCRIPTION
# Summary

Classes provided by vmware_lib are shipped in a separate module, any library in this module that needs to use resources from `vmware_lib` do so by invoking a call on `Puppet::Module.find` to try and determine where the module is in order to require it.

# Problem

This becomes a problem for things like rspec, where you are not inside an instance of Puppet and therefore `Puppet::Module.find` fails since there is no environment to look up against.  While there is no standard/reliable way of looking up libraries from other modules (the practice is actually discouraged by Puppet) I think using `Puppet::Module.find` should be a fall back if the library does not exist in Ruby's load path.    It's also more optimal to just require the class from the load path than to call `Puppet::Module.find`.    This approach was already taken `lib/puppet/provider/vcenter.rb`, but in some types and providers this fall back approach was not used and calls to `Puppet::Module.find` were always done, which breaks rspec, amoungst other things:

```ruby
begin
  require 'puppet_x/puppetlabs/transport'
rescue LoadError => e
  require 'pathname' # WORK_AROUND #14073 and #7788
  vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
  require File.join vmware_module.path, 'lib/puppet_x/puppetlabs/transport'
end
```

# Implementation

Rather than go about putting this logic in 20 or more places in the code base, I've added what might be called pseudo wrapper libraries under `lib/puppet_x/vmware/vmware_lib` - these provide a central place to determine how libraries are loaded outside of the module.  This means within the code base we require vmware_lib by first requiring a _local_ library where we always know the relative path, eg:

```ruby
require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/puppetlabs/transport'
```

This in turn has the logic to try to load `puppet_x/puppetlabs/transport` from the load path, and fall back on `Puppet::Module.find` if that fails.   This also means if vmware_lib has any namespace changes...etc we only have one central place to manage how it gets loaded.

