### PR TITLE
Fixed up testing framework and added some starting tests for types

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,6 @@
 fixtures:
   repositories:
-    staging: 'git://github.com/nanliu/puppet-staging.git'
-    vmware_lib: 'git://github.com/vmware/vmware-vmware_lib.git'
+    staging: 'https://github.com/nanliu/puppet-staging.git'
+    vmware_lib: 'https://github.com/vmware/vmware-vmware_lib.git'
   symlinks:
     'vcenter': "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.1
   - 2.2
 
+
 env:
   - PUPPET_GEM_VERSION="~> 3.2.0"
   - PUPPET_GEM_VERSION="~> 3.7.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,20 @@ language: ruby
 script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
 rvm:
   - 1.9.3
+  - 2.0
+  - 2.1
+  - 2.2
+
 env:
   - PUPPET_GEM_VERSION="~> 3.2.0"
-matrix:
-  include:
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 2.7.0"
-      gemfile: gemfiles/Gemfile.ruby18
+  - PUPPET_GEM_VERSION="~> 3.7.0"
+  - PUPPET_GEM_VERSION="~> 3.8.0"
+  - PUPPET_GEM_VERSION="~> 4.1.0"
+  - PUPPET_GEM_VERSION="~> 4.2.0"
+  - PUPPET_GEM_VERSION="~> 4.3.0"
+  - PUPPET_GEM_VERSION="~> 4.4.0"
+  - PUPPET_GEM_VERSION="~> 4.5.0"
+
 notifications:
   email: false
   flowdock: a4d40af9690ef538447d30fd7f0ececd

--- a/Gemfile
+++ b/Gemfile
@@ -1,26 +1,21 @@
-source 'https://rubygems.org'
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gem 'hashdiff'
 gem 'rbvmomi'
 
-group :development, :test do
-  gem 'rake'
-  gem 'rspec', "~> 2.11.0", :require => false
-  gem 'mocha', "~> 0.10.5", :require => false
-  gem 'puppetlabs_spec_helper', :require => false
-  gem 'rspec-puppet', :require => false
-end
+puppetversion = ENV.key?('PUPPET_VERSION') ? ENV['PUPPET_VERSION'] : ['>= 3.3']
+gem 'metadata-json-lint'
+gem 'puppet', puppetversion
+gem 'puppetlabs_spec_helper', '>= 1.0.0'
+gem 'puppet-lint', '>= 1.0.0'
+gem 'facter', '>= 1.7.0'
+gem 'rspec-puppet'
 
-facterversion = ENV['GEM_FACTER_VERSION']
-if facterversion
-    gem 'facter', facterversion
+# rspec must be v2 for ruby 1.8.7
+if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+  gem 'rspec', '~> 2.0'
+  gem 'rake', '~> 10.0'
 else
-    gem 'facter', :require => false
-end
-
-ENV['GEM_PUPPET_VERSION'] ||= ENV['PUPPET_GEM_VERSION']
-if puppetversion = ENV['GEM_PUPPET_VERSION']
-  gem 'puppet', puppetversion
-else
-  gem 'puppet', :require => false
+  # rubocop requires ruby >= 1.9
+  gem 'rubocop'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,4 @@
 require 'rubygems'
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+$:.unshift File.dirname(__FILE__) + "/fixtures/modules/vmware_lib/lib"

--- a/spec/unit/puppet/type/esx_advanced_optons_spec.rb
+++ b/spec/unit/puppet/type/esx_advanced_optons_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_advanced_options) do
+  parameters = [ :host ]
+  properties = [ :options ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/esx_datasource_spec.rb
+++ b/spec/unit/puppet/type/esx_datasource_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_datastore) do
+  parameters = [ :name, :datastore, :host, :local_path, :access_mode, :user_name, :password, :lun, :uid ]
+  properties = [ :type, :remote_host, :remote_path ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/esx_datastore_spec.rb
+++ b/spec/unit/puppet/type/esx_datastore_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_datastore) do
+  parameters = [ :name, :datastore, :host, :local_path, :access_mode, :user_name, :password, :lun, :uid ]
+  properties = [ :type, :remote_host, :remote_path ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/esx_datastore_spec.rb
+++ b/spec/unit/puppet/type/esx_datastore_spec.rb
@@ -15,4 +15,24 @@ describe Puppet::Type.type(:esx_datastore) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/esx_dnsconfig_spec.rb
+++ b/spec/unit/puppet/type/esx_dnsconfig_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_dnsconfig) do
+  parameters = [ :host ]
+  properties = [ :dhcp, :host_name, :domain_name, :search_domain ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+
+  it "should not allow dhcp false" do
+    expect {
+      described_class.new(:name => "test", :dhcp => :true)
+    }.to raise_error(/This resource only allows disabling dhcp./)
+  end
+
+end

--- a/spec/unit/puppet/type/esx_iscsi_hba_name_spec.rb
+++ b/spec/unit/puppet/type/esx_iscsi_hba_name_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_iscsi_hba_name) do
+  parameters = [ :host_hba, :esx_host, :hba_name ]
+  properties = [ :iscsi_name ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/esx_iscsi_spec.rb
+++ b/spec/unit/puppet/type/esx_iscsi_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_iscsi) do
+  parameters = [ :esx_host ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+end

--- a/spec/unit/puppet/type/esx_iscsi_spec.rb
+++ b/spec/unit/puppet/type/esx_iscsi_spec.rb
@@ -9,4 +9,25 @@ describe Puppet::Type.type(:esx_iscsi) do
     end
   end
 
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
+
 end

--- a/spec/unit/puppet/type/esx_iscsi_targets_spec.rb
+++ b/spec/unit/puppet/type/esx_iscsi_targets_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_iscsi_targets) do
+  parameters = [ :name, :esx_host, :type, :iscsi_hba_device ]
+  properties = [ ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/esx_iscsi_targets_spec.rb
+++ b/spec/unit/puppet/type/esx_iscsi_targets_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:esx_iscsi_targets) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/esx_license_assignment_spec.rb
+++ b/spec/unit/puppet/type/esx_license_assignment_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_license_assignment) do
+  parameters = [ :entity_id ]
+  properties = [ :license_key ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/esx_license_spec.rb
+++ b/spec/unit/puppet/type/esx_license_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_license) do
+  parameters = [ :license_key  ]
+  properties = [ ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/esx_license_spec.rb
+++ b/spec/unit/puppet/type/esx_license_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:esx_license) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/esx_maintmode_spec.rb
+++ b/spec/unit/puppet/type/esx_maintmode_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:esx_maintmode) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/esx_maintmode_spec.rb
+++ b/spec/unit/puppet/type/esx_maintmode_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_maintmode) do
+  parameters = [ :hostseq, :host, :timeout, :evacuate_powered_off_vms ]
+  properties = [ ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/esx_ntpconfig_spec.rb
+++ b/spec/unit/puppet/type/esx_ntpconfig_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_ntpconfig) do
+  parameters = [ :host ]
+  properties = [ :server ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/esx_powerpolicy_spec.rb
+++ b/spec/unit/puppet/type/esx_powerpolicy_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_powerpolicy) do
+  parameters = [ :host ]
+  properties = [ :current_policy ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/esx_service_spec.rb
+++ b/spec/unit/puppet/type/esx_service_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_service) do
+  parameters = [ :name, :service, :host ]
+  properties = [ :running, :policy ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/esx_service_spec.rb
+++ b/spec/unit/puppet/type/esx_service_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
-
 describe Puppet::Type.type(:esx_service) do
   parameters = [ :name, :service, :host ]
   properties = [ :running, :policy ]
+
 
   parameters.each do |parameter|
     it "should have a #{parameter} parameter" do
@@ -15,4 +15,6 @@ describe Puppet::Type.type(:esx_service) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+
 end

--- a/spec/unit/puppet/type/esx_shells_spec.rb
+++ b/spec/unit/puppet/type/esx_shells_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_shells) do
+  parameters = [ :host ]
+  properties = [ :suppress_shell_warning, :esxi_shell_time_out, :esxi_shell_interactive_time_out ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/esx_syslog_spec.rb
+++ b/spec/unit/puppet/type/esx_syslog_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_syslog) do
+  parameters = [ :host ]
+  properties = [ :log_dir, :log_host, :log_dir_unique, :default_rotate, :default_size ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/esx_system_resource_spec.rb
+++ b/spec/unit/puppet/type/esx_system_resource_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_system_resource) do
+  parameters = [
+    :name,
+    :host,
+    :system_resource,
+    :cpu_unlimited,
+    :memory_unlimited
+  ]
+  properties = [
+    :cpu_reservation,
+    :cpu_expandable_reservation,
+    :cpu_limit,
+    :memory_reservation,
+    :memory_expandable_reservation,
+    :memory_limit
+  ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/esx_timezone_spec.rb
+++ b/spec/unit/puppet/type/esx_timezone_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_timezone) do
+  parameters = [ :host ]
+  properties = [ :key ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/esx_vmknic_spec.rb
+++ b/spec/unit/puppet/type/esx_vmknic_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_vmknic) do
+  parameters = [ :name, :esxi_host, :nicname, :portgroup ]
+  properties = [  ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/esx_vmknic_spec.rb
+++ b/spec/unit/puppet/type/esx_vmknic_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:esx_vmknic) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/esx_vmknic_type_spec.rb
+++ b/spec/unit/puppet/type/esx_vmknic_type_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_vmknic_type) do
+  parameters = [ :name, :esxi_host, :nicname ]
+  properties = [ :nic_type ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/prep
+++ b/spec/unit/puppet/type/prep
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cat template.rb | sed "s/NAME/$1/" > $1_spec.rb && vim $1_spec.rb

--- a/spec/unit/puppet/type/template.rb
+++ b/spec/unit/puppet/type/template.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:NAME) do
+  parameters = [ ]
+  properties = [ ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_affinity_spec.rb
+++ b/spec/unit/puppet/type/vc_affinity_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_affinity) do
+  parameters = [ :name, :vm, :rule_type, :path ]
+  properties = [ ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_affinity_spec.rb
+++ b/spec/unit/puppet/type/vc_affinity_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:vc_affinity) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/vc_cluster_drs_spec.rb
+++ b/spec/unit/puppet/type/vc_cluster_drs_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_cluster_drs) do
+  parameters = [ :path ]
+  properties = [ :enabled, :enable_vm_behavior_overrides, :default_vm_behavior, :vmotion_rate ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_cluster_evc_spec.rb
+++ b/spec/unit/puppet/type/vc_cluster_evc_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_cluster_evc) do
+  parameters = [ :path ]
+  properties = [ :evc_mode_key ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_cluster_ha_spec.rb
+++ b/spec/unit/puppet/type/vc_cluster_ha_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_cluster_ha) do
+  parameters = [ :path ]
+  properties = [ ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_cluster_spec.rb
+++ b/spec/unit/puppet/type/vc_cluster_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_cluster) do
+  parameters = [ :path ]
+  properties = [ ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_cluster_spec.rb
+++ b/spec/unit/puppet/type/vc_cluster_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:vc_cluster) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/vc_datacenter_spec.rb
+++ b/spec/unit/puppet/type/vc_datacenter_spec.rb
@@ -9,4 +9,25 @@ describe Puppet::Type.type(:vc_datacenter) do
     end
   end
 
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
+
 end

--- a/spec/unit/puppet/type/vc_datacenter_spec.rb
+++ b/spec/unit/puppet/type/vc_datacenter_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_datacenter) do
+  parameters = [ :path ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+end

--- a/spec/unit/puppet/type/vc_dvportgroup_spec.rb
+++ b/spec/unit/puppet/type/vc_dvportgroup_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_dvportgroup) do
+  parameters = [ :name, :dvswitch_path ]
+  properties = [  ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_dvportgroup_spec.rb
+++ b/spec/unit/puppet/type/vc_dvportgroup_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:vc_dvportgroup) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/vc_dvswitch_migrate_spec.rb
+++ b/spec/unit/puppet/type/vc_dvswitch_migrate_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_dvswitch_migrate) do
+  parameters = [ :name, :host, :dvswitch ]
+  
+  properties = [ ]
+
+  (0..3).each do |i|
+    properties << "vmk#{i}".to_sym
+    properties << "vmnic#{i}".to_sym
+  end
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_dvswitch_nioc_spec.rb
+++ b/spec/unit/puppet/type/vc_dvswitch_nioc_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_dvswitch_nioc) do
+  parameters = [ :name, :path ]
+  properties = [ :network_resource_management_enabled ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_dvswitch_pool_spec.rb
+++ b/spec/unit/puppet/type/vc_dvswitch_pool_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_dvswitch_pool) do
+  parameters = [ :name, :dvswitch_path, :dvswitch_name, :key ]
+  properties = [ :description, :limit, :priority_tag, :shares, :level ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_dvswitch_pool_spec.rb
+++ b/spec/unit/puppet/type/vc_dvswitch_pool_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:vc_dvswitch_pool) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/vc_dvswitch_spec.rb
+++ b/spec/unit/puppet/type/vc_dvswitch_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_dvswitch) do
+  parameters = [ :name, :path ]
+  properties = [ ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_dvswitch_spec.rb
+++ b/spec/unit/puppet/type/vc_dvswitch_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:vc_dvswitch) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/vc_extension_spec.rb
+++ b/spec/unit/puppet/type/vc_extension_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_extension) do
+  parameters = [ :name ]
+  properties = [ ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_extension_spec.rb
+++ b/spec/unit/puppet/type/vc_extension_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:vc_extension) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/vc_folder_spec.rb
+++ b/spec/unit/puppet/type/vc_folder_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:vc_folder) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/vc_folder_spec.rb
+++ b/spec/unit/puppet/type/vc_folder_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_folder) do
+  parameters = [ :path  ]
+  properties = [ ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_host_group_spec.rb
+++ b/spec/unit/puppet/type/vc_host_group_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:vc_host_group) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/vc_host_group_spec.rb
+++ b/spec/unit/puppet/type/vc_host_group_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_host_group) do
+  parameters = [ :name, :path ]
+  properties = [ :hosts ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_host_spec.rb
+++ b/spec/unit/puppet/type/vc_host_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_host) do
+  parameters = [ :name, :username, :password, :sslthumbprint, :secure ]
+  properties = [ :path ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_host_spec.rb
+++ b/spec/unit/puppet/type/vc_host_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:vc_host) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/vc_ip_pool_spec.rb
+++ b/spec/unit/puppet/type/vc_ip_pool_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:vc_ip_pool) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/vc_ip_pool_spec.rb
+++ b/spec/unit/puppet/type/vc_ip_pool_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_ip_pool) do
+  parameters = [ :label, :datacenter, :force_destroy ]
+  properties = [  ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_storagepod_spec.rb
+++ b/spec/unit/puppet/type/vc_storagepod_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:vc_storagepod) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/vc_storagepod_spec.rb
+++ b/spec/unit/puppet/type/vc_storagepod_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_storagepod) do
+  parameters = [ :cluster, :datacenter ]
+  properties = [ :datastores ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_vm_group_spec.rb
+++ b/spec/unit/puppet/type/vc_vm_group_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:vc_vm_group) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/vc_vm_group_spec.rb
+++ b/spec/unit/puppet/type/vc_vm_group_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_vm_group) do
+  parameters = [ :name, :path ]
+  properties = [ :vms ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_vm_host_rule_spec.rb
+++ b/spec/unit/puppet/type/vc_vm_host_rule_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_vm_host_rule) do
+  parameters = [ :name, :path ]
+  properties = [ ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_vm_host_rule_spec.rb
+++ b/spec/unit/puppet/type/vc_vm_host_rule_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:vc_vm_host_rule) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/vc_vm_spec.rb
+++ b/spec/unit/puppet/type/vc_vm_spec.rb
@@ -15,4 +15,24 @@ describe Puppet::Type.type(:vc_vm) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/vc_vm_spec.rb
+++ b/spec/unit/puppet/type/vc_vm_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_vm) do
+  parameters = [ :name, :cpucount, :memory, :guestid, :datastore, :graceful_shutdown, :datacenter_name ]
+  properties = [ :power_state ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vc_vpxsettings_spec.rb
+++ b/spec/unit/puppet/type/vc_vpxsettings_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vc_vpxsettings) do
+  parameters = [ :name ]
+  properties = [ :vpx_settings ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vm_harddisk_spec.rb
+++ b/spec/unit/puppet/type/vm_harddisk_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vm_harddisk) do
+  parameters = [ :name, :vm_name, :datacenter, :datastore, :thin_provisioned, :eager_scrub, :remove_disk ]
+  properties = [ ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vm_harddisk_spec.rb
+++ b/spec/unit/puppet/type/vm_harddisk_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:vm_harddisk) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/vm_hardware_spec.rb
+++ b/spec/unit/puppet/type/vm_hardware_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vm_hardware) do
+  parameters = [ :vm_name, :datacenter ]
+  properties = [ ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vm_nic_spec.rb
+++ b/spec/unit/puppet/type/vm_nic_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:vm_nic) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/vm_nic_spec.rb
+++ b/spec/unit/puppet/type/vm_nic_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vm_nic) do
+  parameters = [ :name, :vm_name, :datacenter, :portgroup_type ]
+  properties = [ ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vm_tools_config_spec.rb
+++ b/spec/unit/puppet/type/vm_tools_config_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vm_tools_config) do
+  parameters = [ :name, :vm_name, :datacenter ]
+  properties = [
+    :after_power_on,
+    :after_resume,
+    :before_guest_reboot,
+    :before_guest_shutdown,
+    :before_guest_standby,
+    :sync_time_with_host,
+    :tools_upgrade_policy
+  ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end

--- a/spec/unit/puppet/type/vm_vapp_property_spec.rb
+++ b/spec/unit/puppet/type/vm_vapp_property_spec.rb
@@ -26,4 +26,25 @@ describe Puppet::Type.type(:vm_vapp_property) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  ## This type is ensurable
+  ## some basic provider sanity checking, check that this type has matching provider
+  ## and check that all providers of this type support, at the minimum, an
+  ## exists?, create and destroy method.
+  #
+  it "should have one or more providers" do
+    expect(described_class.providers).not_to be_empty
+  end
+
+  described_class.providers.each do |provider|
+    it "the #{provider} provider should support an exists? method" do
+      expect(described_class.provider(provider).instance_method(:exists?)).not_to be_nil
+    end
+    it "the #{provider} provider should support a create method" do
+      expect(described_class.provider(provider).instance_method(:create)).not_to be_nil
+    end
+    it "the #{provider} provider should support a destroy method" do
+      expect(described_class.provider(provider).instance_method(:destroy)).not_to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/vm_vapp_property_spec.rb
+++ b/spec/unit/puppet/type/vm_vapp_property_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vm_vapp_property) do
+  parameters = [ :name, :vm_name, :datacenter ]
+  properties = [
+    :category,
+    :class_id,
+    :default_value,
+    :description,
+    :id,
+    :instance_id,
+    :label,
+    :type,
+    :user_configurable,
+    :value
+  ]
+
+  parameters.each do |parameter|
+    it "should have a #{parameter} parameter" do
+      expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  properties.each do |property|
+    it "should have a #{property} property" do
+      expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+end


### PR DESCRIPTION

This PR fixes up the testing framework around the module with a new and updated test matrix.

I've also added some very basic rspec tests for all of the custom types within this module, right now they are pretty boilerplate but provide a starting point that we can build on. As we make changes to types and providers in this module we should build out their rspec tests too.   Currently, this just tests for:

* All properties are defined, and defined as properties
* All parameters are defined, and defined as parameters
* For ensurable resource types, that all providers support `create`, `destroy` and `exists?`

This PR will fail tests because #177 is needed alongside this PR to make it all work together nicely.

A successful travis run, on a branch consisting of this PR and #177 together can be reviewed here;

https://travis-ci.org/crayfishx/vmware-vcenter/builds/136640863