### PR TITLE
Transport failure with Vc_dvswitch_nioc and vc_dvportgroup

### DIFF
--- a/manifests/dvportgroup.pp
+++ b/manifests/dvportgroup.pp
@@ -22,6 +22,7 @@ define vcenter::dvportgroup (
     # vsphere property 'name' is 'dvportgroup_name'
     dvportgroup_name     => $dvportgroup_name,
     ensure               => $ensure,
+    transport            => $transport,
    
     # provider will set spec.configVersion automatically
     #onfig_version       => nested_value($spec, ['configVersion']),

--- a/manifests/dvswitch.pp
+++ b/manifests/dvswitch.pp
@@ -15,7 +15,8 @@ define vcenter::dvswitch (
 # http://pubs.vmware.com/vsphere-51/topic/com.vmware.wssdk.apiref.doc/right-pane.html
 
   vc_dvswitch_nioc { $name:
-    network_resource_management_enabled => $networkResourceManagementEnabled
+    network_resource_management_enabled => $networkResourceManagementEnabled,
+    transport => $transport,
   }
 
   vc_dvswitch { $name:


### PR DESCRIPTION
Added the transport parameter to the vc_dvswitch_nioc and vc_dvportgroup resources to address an undefined method error.
`Error: /Stage[main]/Vrealm_profiles::Vcenter/Vcenter::Dvswitch[/d3p6v18/d3p6v18:configure]/Vc_dvswitch_nioc[/d3p6v18/d3p6v18:configure]: Could not evaluate: undefined method 'server' for nil:NilClass`