### PR TITLE
Changed require path for transport/vsphere

### DIFF
--- a/lib/puppet/provider/vcenter.rb
+++ b/lib/puppet/provider/vcenter.rb
@@ -4,7 +4,7 @@
 module_lib = Pathname.new(__FILE__).parent.parent.parent
 
 require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/puppetlabs/transport'
-require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/puppetlabs/transport/vsphere'
+require File.join module_lib, 'puppet_x/puppetlabs/transport/vsphere'
 require File.join module_lib, 'puppet_x/vmware/vmware_lib/puppet_x/vmware/util'
 
 


### PR DESCRIPTION
In #177 we changed the require paths and @maniacmurphy pointed out that `puppet_x/puppetlabs/transport/vsphere` was now provided by the vcenter module, this PR fixes a broken require that still assumed it was in vmware_lib.

