### PR TITLE
Fix build problem for Ruby 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,3 +19,9 @@ else
   # rubocop requires ruby >= 1.9
   gem 'rubocop'
 end
+
+# JSON must be 1.x on Ruby 1.9
+if RUBY_VERSION < '2.0'
+  gem 'json', '~> 1.8'
+end
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/vmware/vmware-vcenter.svg?branch=master)](https://travis-ci.org/vmware/vmware-vcenter)
+
 # VMware vCenter module
 
 This module manages resources in VMware vCenter such as folders, datacenter,


### PR DESCRIPTION

There are still two problems with the travis build - firstly there is a broken require fixed in #182 - secondly, the JSON gem fails on 1.9 as it needs to be bound to version 1.x - I've fixed that in the Gemfile

When #182 and this PR is merged we should have a green test board.
