### PR TITLE
Update name parameter for vm_vapp_property

### DIFF
--- a/lib/puppet/type/vm_vapp_property.rb
+++ b/lib/puppet/type/vm_vapp_property.rb
@@ -17,7 +17,11 @@ Puppet::Type.newtype(:vm_vapp_property) do
     desc 'The datacenter, vm name and visible label of the property split by a colon (:). Format dc1:vm1:label'
 
     munge do |value|
-      @resource[:datacenter], @resource[:vm_name], @resource[:label] = value.split(':',3)
+      if value =~ /^[a-zA-Z0-9\-\. ]+:[a-zA-Z0-9\-\. ]+:[a-zA-Z0-9\-\. ]+$/ then
+        @resource[:datacenter], @resource[:vm_name], @resource[:label] = value.split(':',3)
+      else
+        @resource[:label] = value
+      end
     end
   end
 

--- a/lib/puppet/type/vm_vapp_property.rb
+++ b/lib/puppet/type/vm_vapp_property.rb
@@ -17,8 +17,9 @@ Puppet::Type.newtype(:vm_vapp_property) do
     desc 'The datacenter, vm name and visible label of the property split by a colon (:). Format dc1:vm1:label'
 
     munge do |value|
-      if value =~ /^[a-zA-Z0-9\-\. ]+:[a-zA-Z0-9\-\. ]+:[a-zA-Z0-9\-\. ]+$/ then
-        @resource[:datacenter], @resource[:vm_name], @resource[:label] = value.split(':',3)
+      a = value.split(':',3)
+      if a.size == 3 then
+        @resource[:datacenter], @resource[:vm_name], @resource[:label] = a
       else
         @resource[:label] = value
       end


### PR DESCRIPTION
Added statement to decouple label from datacenter and vm_name without breaking existing functionality.

If name matches the pattern dc:vm:label ti splits as normal.
Otherwise label = name