### PR TITLE
Added better validation of transport in vcenter provider

### DIFF
--- a/lib/puppet/provider/vcenter.rb
+++ b/lib/puppet/provider/vcenter.rb
@@ -14,6 +14,19 @@ class Puppet::Provider::Vcenter <  Puppet::Provider
   private
 
   def vim
+    unless resource[:transport]
+      raise Puppet::Error, "No transport metaparameter provided for #{resource.ref}"
+    end
+    unless resource[:transport].is_a?(Puppet::Resource)
+      raise Puppet::Error, "Invalid transport #{resource[:transport]} provided for #{resource.ref}"
+    end
+    unless resource[:transport].type == "Transport"
+      raise Puppet::Error, "Transport metaparameter must be of type Transport for #{resource.ref}"
+    end
+    unless resource.catalog.resource_refs.include?(resource[:transport].to_s)
+      raise Puppet::Error, "Transport #{resource[:transport].to_s} not defined for #{resource.ref}"
+    end
+
     @transport ||= PuppetX::Puppetlabs::Transport.retrieve(:resource_ref => resource[:transport], :catalog => resource.catalog, :provider => 'vsphere')
     @transport.vim
   end


### PR DESCRIPTION

As raised in #186 when you don't pass, or pass a malformed, transport metaparameter you get some rather cryptic errors that are hard to track down - this PR adds some sanity checking to the vcenter provider when `vim` is called.

It checks on 4 factors...

````
vc_datacenter { 'foo': .... } # Missing transport
Could not evaluate: No transport metaparameter provided for Vc_datacenter[foo]
```

```
vc_datacenter { 'foo':... transport => Transport['missing'] } # undeclared transport
Could not evaluate: Transport Transport[missing] not defined for Vc_datacenter[foo]
```

```
vc_datacenter { 'foo': .... transport => "bad string" } # non-resource reference
Could not evaluate: Invalid transport bad string provided for Vc_datacenter[foo]
```

```
vc_datacenter { 'foo': .... transport => Package['foo'] } # Not a Transport type
Could not evaluate: Transport metaparameter must be of type Transport for Vc_datacenter[foo]
```
