### PR TITLE
pin json_pure to fix tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,5 +23,6 @@ end
 # JSON must be 1.x on Ruby 1.9
 if RUBY_VERSION < '2.0'
   gem 'json', '~> 1.8'
+  gem 'json_pure', '~> 1.0'
 end
 


### PR DESCRIPTION
CI is failing for ruby versions less than 2.0 because of gem incompatibility