### PR TITLE
esx_advanced_options: convert integers to strings

### DIFF
--- a/lib/puppet/type/esx_advanced_options.rb
+++ b/lib/puppet/type/esx_advanced_options.rb
@@ -8,6 +8,13 @@ Puppet::Type.newtype(:esx_advanced_options) do
 
   newproperty(:options) do
     desc "a hash with options and values"
+    munge do |value|
+      value.inject(value) do |h,(k,v)|
+        h[k] = v.is_a?(Integer) ? v.to_s : v
+        h
+      end
+      value
+    end
   end
 
   autorequire(:vc_host) do

--- a/spec/unit/puppet/type/esx_advanced_optons_spec.rb
+++ b/spec/unit/puppet/type/esx_advanced_optons_spec.rb
@@ -15,4 +15,25 @@ describe Puppet::Type.type(:esx_advanced_options) do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
     end
   end
+
+  context "when initialized with options" do
+    let(:resource) {
+      options = {
+        "integer.option" => 1001,
+        "string.option" =>  "1002",
+        "boolean.option" => true,
+      }
+      described_class.new(:name => 'esxihost', :options => options)
+    }
+
+    it "should change integers to strings" do
+      expect(resource[:options]["integer.option"]).to be_a(String)
+    end
+
+    it "should not change booleans" do
+      expect(resource[:options]["boolean.option"]).to eq(true)
+    end
+
+  end
+
 end


### PR DESCRIPTION

As discussed in #175  (and also raised in #172) if integers are supplied from the `esx_advanced_options` resource type there is some hard to identify behaviour.  Since the solution is to always provide numbers as strings, this PR munges the given hash in the resource type so integers are converted into strings.

Note, I assume that booleans and possibly other types are valid, therefore we only convert integers to strings.

Tests added to assert the above.

