### PR TITLE
Refactored esx_system_resource to handle cpu and memory unlimited

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,14 +156,12 @@ The service name should be in the form of: `ESXi_hostname:<service name`. Eg `es
 This resource allows the configuration of system resources of a host that are viewed und er the 'System Resource Allocation' section of the vSphere client
 * `host`:
 * `system_resource`:
-* `cpu_limit`:
+* `cpu_limit`: Can be set to a numerical value representing MHz, or "unlimited"
 * `cpu_reservation`:
 * `cpu_expandable_reservation`:
-* `memory_limit`:
+* `memory_limit`: Can be set to a numerical value representing MB, or "unlimited"
 * `memory_reservation`:
 * `memory_expandable_reservation`:
-* `cpu_unlimited`: Enable unlimited CPU resources. Can't be used in conjunction with `cpu_limit`
-* `memory_unlimited`: Enable unlimited Memory resources. Can't be used in conjunction with `memory_limit`
 * `transport`: A resource reference to a transport type declared elsewhere. Eg: `Transport['vcenter']`
 
 ### esx_timezone

--- a/lib/puppet/type/esx_system_resource.rb
+++ b/lib/puppet/type/esx_system_resource.rb
@@ -25,22 +25,17 @@ Puppet::Type.newtype(:esx_system_resource) do
   end
 
   newproperty(:cpu_limit) do
-    desc "CPU limit in MHz"
-    newvalues(/\d{1,}/)
-  end
-
-  newparam(:cpu_unlimited) do
-    desc "Enable unlimited CPU resources"
-    newvalues(:true,:false)
+    desc <<-EOT
+    Sets the CPU limit.  Acceptable values are a numeric value (in Mhz) or
+    the string "unlimited"
+    EOT
+    newvalues(/\d{1,}/, "unlimited")
     munge do |value|
-      if value == 'true'
-        @resource[:cpu_limit] = -1
-      elsif value == 'false' && !(@resource[:cpu_limit])
-        @resource[:cpu_limit] = 0
-      end
+      value = -1 if value == "unlimited"
+      value
     end
   end
- 
+
   newproperty(:memory_reservation) do
     desc "System resource memory reservation in MB"
     newvalues(/\d{1,}/)
@@ -52,19 +47,15 @@ Puppet::Type.newtype(:esx_system_resource) do
   end
  
   newproperty(:memory_limit) do
-    desc "Memory limit in MB"
-    newvalues(/\d{1,}/)
+    desc <<-EOT
+    Sets the memory limit.  Acceptable values are a numeric value (in MB) or
+    the string "unlimited"
+    EOT
+    newvalues(/\d{1,}/, "unlimited")
+    munge do |value|
+      value = -1 if value == "unlimited"
+      value
+    end
   end
 
-   newparam(:memory_unlimited) do
-     desc "Enable unlimited Memory resources"
-     newvalues(:true,:false)
-     munge do |value|
-       if value == 'true'
-         @resource[:memory_limit] = -1
-       elsif value == 'false' && !(@resource[:memory_limit])
-         @resource[:memory_limit] = 0
-       end
-     end
-   end
 end

--- a/spec/unit/puppet/type/esx_system_resource_spec.rb
+++ b/spec/unit/puppet/type/esx_system_resource_spec.rb
@@ -5,8 +5,6 @@ describe Puppet::Type.type(:esx_system_resource) do
     :name,
     :host,
     :system_resource,
-    :cpu_unlimited,
-    :memory_unlimited
   ]
   properties = [
     :cpu_reservation,
@@ -26,6 +24,31 @@ describe Puppet::Type.type(:esx_system_resource) do
   properties.each do |property|
     it "should have a #{property} property" do
       expect(described_class.attrclass(property).ancestors).to be_include(Puppet::Property)
+    end
+  end
+
+  context "cpu resources" do
+    it "should set cpu_limit to -1 when unlimited" do
+      expect(
+        described_class.new(
+          :name => 'foo', :cpu_limit => 'unlimited')[:cpu_limit]
+      ).to eq(-1)
+      expect(
+        described_class.new(
+          :name => 'foo', :cpu_limit => 400)[:cpu_limit]
+      ).to eq(400)
+    end
+  end
+  context "memory resources" do
+    it "should set memory_limit to -1 when unlimited" do
+      expect(
+        described_class.new(
+          :name => 'foo', :memory_limit => 'unlimited')[:memory_limit]
+      ).to eq(-1)
+      expect(
+        described_class.new(
+          :name => 'foo', :memory_limit => 400)[:memory_limit]
+      ).to eq(400)
     end
   end
 end


### PR DESCRIPTION

This PR is in response to #171 and is an API breaking change to the `esx_system_resource` type

* Deprecates `cpu_unlimited` and `memory_unlimited` attributes
* Adds `unlimited` as an acceptable parameter to `cpu_limit` and `memory_limit`

Discussion and justification can be followed in #171 