### PR TITLE
New type to manage ESX firewall rulesets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ options => {
 * `debug`: true, false
 * `transport`: A resource reference to a transport type declared elsewhere. Eg: `Transport['vcenter']`
 
+### esx_firewall_ruleset
+#### Parameters
+* `ensure`: enabled, disabled
+* `name`: Name of the firewall ruleset (namevar)
+* `host`: ESX host to configure (namevar)
+* `path`:  Path to the datacenter where the host resides
+* `allowed_hosts`: Accepts a string value of "all" or an array of IP addresses and IP networks with prefixes
+* `transport`: A resource reference to a transport type declared elsewhere. Eg: `Transport['vcenter']`
+
+#### Title pattern
+
+Both `name` and `host` are namevars, by default the title will be used for `name`, but both may be specified in the title as `host:name`
+
 ### esx_dnsconfig
 #### Parameters
 * `address`: ['array','of','dns','values']

--- a/lib/puppet/provider/esx_firewall_ruleset/default.rb
+++ b/lib/puppet/provider/esx_firewall_ruleset/default.rb
@@ -1,0 +1,101 @@
+provider_path = Pathname.new(__FILE__).parent.parent
+require File.join(provider_path, 'vcenter')
+require 'rbvmomi'
+
+Puppet::Type.type(:esx_firewall_ruleset).provide(
+  :default, 
+  :parent => Puppet::Provider::Vcenter
+) do
+
+
+  @doc = "Manages ESXi firewall rulesets"
+
+  def enable
+    firewall_config.EnableRuleset(:id => @resource[:name])
+  end
+
+  def disable
+    firewall_config.DisableRuleset(:id => @resource[:name])
+  end
+
+  #Check for existence of vSwitch
+  def enabled?
+    ruleset(resource[:name]).enabled
+  end
+
+  def allowed_hosts
+    hosts = ruleset(resource[:name]).allowedHosts
+    return "all" if hosts.allIp
+    ips = []
+    ips << hosts.ipAddress
+    hosts.ipNetwork.each do |cidr|
+      ips << "#{cidr.network}/#{cidr.prefixLength}"
+    end
+    ips.flatten
+  end
+
+  def allowed_hosts=(should)
+    all_ip=nil
+    networks=[]
+    ipaddresses=[]
+
+    if should == [ 'all' ]
+      all_ip=true
+    else
+      all_ip=false
+      should.each do |ip|
+        address, prefix = ip.split(/\//)
+        if prefix.nil?
+          ipaddresses << address
+        else
+          networks << {
+            :network => address,
+            :prefixLength => prefix
+          }
+        end
+      end
+    end
+
+    firewall_config.UpdateRuleset(
+      :id => @resource[:name],
+      :spec => {
+        :allowedHosts => {
+          :allIp => all_ip,
+          :ipAddress => ipaddresses,
+          :ipNetwork => networks
+        }
+      }
+    )
+  end
+
+
+
+  def ruleset(name)
+    set = firewall_config.firewallInfo.ruleset.select { |r| 
+      r.key == name 
+    }
+    raise Puppet::Error, "No firewall ruleset named #{name}" if set.empty?
+    set[0]
+  end
+
+
+
+  def firewall_config
+    @firewall_config ||= esx_host.configManager.firewallSystem
+    @firewall_config
+  end
+
+  # TODO: centralize this for all esx providers!
+
+  def walk_dc(path=resource[:path])
+    datacenter = walk(path, RbVmomi::VIM::Datacenter)
+    raise Puppet::Error.new( "No datacenter in path: #{path}") unless datacenter
+    datacenter
+  end
+
+  def esx_host
+    @esx_host ||= vim.searchIndex.FindByDnsName(:datacenter => walk_dc, :dnsName => resource[:host], :vmSearch => false)
+    raise Puppet::Error.new("An invalid host name or IP address is entered. Enter the correct host name and IP address.") unless @esx_host
+    @esx_host
+  end
+end

--- a/lib/puppet/type/esx_firewall_ruleset.rb
+++ b/lib/puppet/type/esx_firewall_ruleset.rb
@@ -1,0 +1,113 @@
+Puppet::Type.newtype(:esx_firewall_ruleset) do
+  @doc = <<-EOT
+  This type manages ESX firewall rulesets on a host.  This title has two namevars
+  host and name, the name may be specified in the title, or both the name and the
+  host delimited with a comma, eg;
+
+
+  esx_firewall_ruleset { 'ntp rule':
+    ensure    => enabled,
+    name      => 'ntpClient',
+    host      => 'esxi1.localdomain',
+    transport => Transport['vcenter'],
+  }
+
+  esx_firewall_ruleset { 'ntpClient':
+    ensure    => enabled,
+    host      => 'esxi1.localdomain',
+    transport => Transport['vcenter'],
+  }
+
+  esx_firewall_ruleset { 'esxi1.localdomain:ntpClient':
+    ensure    => enabled,
+    transport => Transport['vcenter'],
+  }
+
+  EOT
+
+  def self.title_patterns
+    identity = lambda { |x| x }
+    [ 
+      [ 
+        /^([^:]+):([^:]+)$/,
+        [ [:host, identity], [:name, identity] ]
+      ],
+      [
+        /^([^:]+)$/,
+        [[ :name, identity ]]
+      ]
+    ]
+  end
+
+  validate do
+    raise ArgumentError, "Must supply path" unless self[:path]
+    raise ArgumentError, "Must supply host in title or host attribute" unless self[:host]
+  end
+
+  ensurable do
+    desc <<-EOT
+    Valid ensure values are "enabled" and "disabled" (present and absent will also
+    map to their respective values)
+    EOT
+    newvalue(:enabled) do
+      provider.enable
+    end
+    newvalue(:disabled) do
+      provider.disable
+    end
+
+    aliasvalue :absent, :disabled
+    aliasvalue :present, :enabled
+    defaultto(:enabled)
+
+    def retrieve
+      provider.enabled? ? :enabled : :disabled
+    end
+  end
+
+  newparam(:path) do
+    desc "Datacenter path where host resides"
+    validate do |path|
+      raise ArgumentError, "Absolute path is required: #{path}" unless Puppet::Util.absolute_path?(path)
+    end
+  end
+
+  newparam(:name) do
+    desc "The name of the firewall rulset, eg: ntpClient"
+    isnamevar
+  end
+
+  newparam(:host) do
+    isnamevar
+    desc "ESX host to configure"
+  end
+
+  newproperty(:allowed_hosts, :array_matching => :all) do
+    desc <<-EOT
+      A list of allowed IP ranges
+
+      This attribute can take a single string value of "all" indicating that
+      all IP addresses are allowed for this ruleset, alternatively an array
+      of IP addresses, or IP address ranges with prefixes may be given.
+
+      Allow all hosts
+      allowed_hosts => 'all'
+
+      Allow multiple hosts
+      allowed_hosts => [
+        '192.168.10.2',
+        '192.168.200.0/24',
+        '10.72.99.0/24'
+      ]
+    EOT
+    validate do |value|
+      unless ( value =~ /^\d+\.\d+\.\d+.\d+(\/\d+|)$/ || value == 'all' )
+        raise Puppet::Error, "malformed IP address or network #{value}"
+      end
+    end
+
+    def insync?(is)
+      Array(is).sort == Array(should).sort
+    end
+  end
+end

--- a/spec/unit/puppet/type/esx_firewall_ruleset_spec.rb
+++ b/spec/unit/puppet/type/esx_firewall_ruleset_spec.rb
@@ -1,0 +1,160 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:esx_firewall_ruleset) do
+
+  context 'when invoked' do
+    let(:title) { 'ntpClient' }
+    let(:params) {{
+      :path => '/data/center/',
+      :host => '192.168.2.2',
+    }}
+    it "should compile" do
+      expect { compile }
+    end
+  end
+
+  context 'namevar' do
+    it "should have name and host as its keyattribute" do
+      expect(described_class.key_attributes).to include( :name, :host )
+    end
+  end
+  context 'when declared using title as namevar' do
+    let(:resource) {
+      described_class.new(
+        :title => 'ntpClient',
+        :path  => '/data/center',
+        :host  => '192.168.22.1'
+      )
+    }
+
+    it "should set the name to the title" do
+      expect(resource.name).to eq('ntpClient')
+    end
+  end
+
+  context 'when declared with the name parameter' do
+    let (:resource) {
+      described_class.new(
+        :title => 'discard',
+        :name  => 'ntpClient',
+        :path  => '/data/center',
+        :host  => '192.168.22.1'
+      )
+    }
+
+    it "should set the name to the title" do
+      expect(resource.name).to eq('ntpClient')
+    end
+  end
+
+  context "the path attribute" do
+    let (:params) {{
+        :title => 'discard',
+        :name  => 'ntpClient',
+        :host  => '192.168.22.1'
+    }}
+    it "should raise an error if path is missing" do
+      expect { described_class.new }.to raise_error(ArgumentError)
+    end
+    it "should raise an error if the path is not absolute" do
+      params[:path] = 'foo'
+      expect { described_class.new }.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'when declared with comma delimited title' do
+    let (:resource) {
+      described_class.new(
+        :title => '192.168.22.1:ntpClient',
+        :path  => '/data/center',
+      )
+    }
+
+    it "should set the host and name from the namevar" do
+      expect(resource.name).to eq('ntpClient')
+      expect(resource[:host]).to eq('192.168.22.1')
+    end
+  end
+
+  context "the ensure attribute" do
+    let (:params) {{
+      :title => '192.168.22.1:ntpClient',
+      :path  => '/data/center',
+    }}
+
+    it "should allow values of enabled,disabled,present or absent" do
+      [ 'enabled', 'disabled', 'present', 'absent' ].each do |p|
+        expect { described_class.new(params.merge({:ensure => p})) }.not_to raise_error
+      end
+    end
+
+    it "should raise error on any other value" do
+      params[:ensure] = 'bad_state'
+      expect {  described_class.new(params) }.to raise_error(Puppet::Error)
+    end
+
+    it "should map present to enabled" do
+      params[:ensure] = 'present'
+      expect(described_class.new(params)[:ensure]).to eq(:enabled)
+    end
+
+    it "should map absent to disabled" do
+      params[:ensure] = 'absent'
+      expect(described_class.new(params)[:ensure]).to eq(:disabled)
+    end
+  end
+      
+
+  context "when validating allowed_hosts" do
+     let(:params) {{
+        :title => '192.168.22.1:ntpClient',
+        :path  => '/data/center',
+     }}
+
+     it "should allow the string 'all'" do
+       params['allowed_hosts'] = 'all'
+       expect { described_class.new(params) }.not_to raise_error
+     end
+
+     it "should allow an array" do
+       params['allowed_hosts'] = [ '192.168.21.1', '192.168.21.2', '192.168.99.0/24' ]
+       expect { described_class.new(params) }.not_to raise_error
+     end
+     
+     it "should not allow any other string" do
+       params['allowed_hosts'] = 'bad'
+       expect { described_class.new(params) }.to raise_error(Puppet::Error)
+     end
+
+     it "should not allow a malformed ip address in the array" do
+       params['allowed_hosts'] = [ '192.168.21.1', '192.168.21.2/BAD', '192.168.99.0/24' ]
+       expect { described_class.new(params) }.to raise_error(Puppet::Error)
+     end
+  end
+
+  context "when evaluating allowedhosts" do
+     let(:params) {{
+        :ensure => :enabled,
+        :title => '192.168.22.1:ntpClient',
+        :path  => '/data/center',
+        :allowed_hosts => [ '192.168.21.1', '192.168.21.2', '192.168.99.0/24' ],
+     }}
+     let(:resource) { described_class.new(params) }
+
+     it "should not care about the order" do
+       is =  [ '192.168.99.0/24', '192.168.21.1', '192.168.21.2']
+       expect(resource.property(:allowed_hosts).insync?(is)).to eq(true)
+     end
+
+     it "should recognise removed values as out of sync" do
+       is =  [ '192.168.21.2', '192.168.99.0/24' ]
+       expect(resource.property(:allowed_hosts).insync?(is)).to eq(false)
+     end
+
+     it "should recognise new values as out of sync" do
+       is = [ '192.168.21.1', '192.168.21.2', '192.168.99.0/24', '10.0.0.1' ]
+       expect(resource.property(:allowed_hosts).insync?(is)).to eq(false)
+     end
+
+  end
+end


### PR DESCRIPTION

## Summary

This PR introduces a new resource type and provider to manage ESX firewall rulesets on a host, it supports enabling and disabling the ruleset and adding and removing allowed hosts.

## Smoke testing/examples....

```puppet
Esx_firewall_ruleset {
  path      => '/vc1/vc.dc',
  transport => Transport['vcenter'],
}

esx_firewall_ruleset { '192.168.245.212:ntpClient':
  ensure        => 'enabled',
  allowed_hosts => 'all',
}
```

```
Notice: /Stage[main]/Main/Esx_firewall_ruleset[192.168.245.212:ntpClient]/ensure: ensure changed 'disabled' to 'enabled'
```

```puppet
esx_firewall_ruleset { '192.168.245.212:ntpClient':
  ensure        => enabled,
  allowed_hosts => [
    "10.0.0.1",
    "192.168.100.0/24"
  ],
}
```

```
Notice: /Stage[main]/Main/Esx_firewall_ruleset[192.168.245.212:ntpClient]/allowed_hosts: allowed_hosts changed 'all' to '10.0.0.1 192.168.100.0/24'
```

```puppet
esx_firewall_ruleset { '192.168.245.212:ntpClient':
  ensure        => disabled
}
```

```
Notice: /Stage[main]/Main/Esx_firewall_ruleset[192.168.245.212:ntpClient]/ensure: ensure changed 'enabled' to 'disabled'
```

```puppet
esx_firewall_ruleset { 'random title':
  ensure        => enabled,
  name          => 'ntpClient',
  host          => '192.168.245.212',
  allowed_hosts => 'all',
}
```

```
Notice: /Stage[main]/Main/Esx_firewall_ruleset[random title]/ensure: ensure changed 'disabled' to 'enabled'
```