### PR TITLE
Fix to testing framework, puppet versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Gemfile.lock
 lib/puppet/type/esx_debug.rb
 lib/puppet/provider/esx_debug/default.rb
 *.gem

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ rvm:
 
 
 env:
-  - PUPPET_GEM_VERSION="~> 3.2.0"
-  - PUPPET_GEM_VERSION="~> 3.7.0"
-  - PUPPET_GEM_VERSION="~> 3.8.0"
-  - PUPPET_GEM_VERSION="~> 4.1.0"
-  - PUPPET_GEM_VERSION="~> 4.2.0"
-  - PUPPET_GEM_VERSION="~> 4.3.0"
-  - PUPPET_GEM_VERSION="~> 4.4.0"
-  - PUPPET_GEM_VERSION="~> 4.5.0"
+  - PUPPET_VERSION="~> 3.2.0"
+  - PUPPET_VERSION="~> 3.7.0"
+  - PUPPET_VERSION="~> 3.8.0"
+  - PUPPET_VERSION="~> 4.1.0"
+  - PUPPET_VERSION="~> 4.2.0"
+  - PUPPET_VERSION="~> 4.3.0"
+  - PUPPET_VERSION="~> 4.4.0"
+  - PUPPET_VERSION="~> 4.5.0"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ env:
 matrix:
   exclude:
     - rvm: 2.2
+      env: PUPPET_VERSION="~> 3.6.0"
+    - rvm: 2.2
       env: PUPPET_VERSION="~> 3.7.0"
     - rvm: 2.2
       env: PUPPET_VERSION="~> 3.8.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
 
 
 env:
-  - PUPPET_VERSION="~> 3.2.0"
+  - PUPPET_VERSION="~> 3.6.0"
   - PUPPET_VERSION="~> 3.7.0"
   - PUPPET_VERSION="~> 3.8.0"
   - PUPPET_VERSION="~> 4.1.0"
@@ -16,6 +16,13 @@ env:
   - PUPPET_VERSION="~> 4.3.0"
   - PUPPET_VERSION="~> 4.4.0"
   - PUPPET_VERSION="~> 4.5.0"
+
+matrix:
+  exclude:
+    - rvm: 2.2
+      env: PUPPET_VERSION="~> 3.7.0"
+    - rvm: 2.2
+      env: PUPPET_VERSION="~> 3.8.0"
 
 notifications:
   email: false


### PR DESCRIPTION
Due to a mismatch between PUPPET_GEM_VERSION and PUPPET_VERSION in the Gemfile and .travis.yml we weren't actually testing against different versions of Puppet, all tests were being run against the same version.  This PR fixes that and adds the "known to fail" combinations as exclusions... all tests are passing, and, errr, working now.