### PR TITLE
VM-host affinity rule

### DIFF
--- a/lib/puppet/provider/vc_vm_group/default.rb
+++ b/lib/puppet/provider/vc_vm_group/default.rb
@@ -73,7 +73,7 @@ Puppet::Type.type(:vc_vm_group).provide(:vc_vm_group, :parent => Puppet::Provide
   def vm_list(vm_names)
     @vms ||= 
       begin  
-        vms = find_rp_vms(cluster.resourcePool, vm_names)
+        vms = find_vms(cluster, vm_names)
         vms.uniq { |vm| vm._ref}
       end
   end
@@ -81,26 +81,21 @@ Puppet::Type.type(:vc_vm_group).provide(:vc_vm_group, :parent => Puppet::Provide
   def match_vm(matches, vm)
     matched_vms = []
     matches.each do |match|
-      matched_vms << vm if vm.name =~ /#{match}/
+      matched_vms << vm if vm.name == match
     end
     matched_vms
   end
 
- def find_rp_vms(resourcepool,vm_names)
-    @vm_obj ||= []
-    resourcepool.childConfiguration.each do |child|
-      case child.entity
-      when RbVmomi::VIM::VirtualMachine
-        @vm_obj << match_vm(vm_names, child.entity) 
-      when RbVmomi::VIM::VirtualApp
-        find_rp_vms(child.entity, vm_names)
-      when RbVmomi::VIM::ResourcePool
-        find_rp_vms(child.entity, vm_names)
-      else
-        Puppet.warning "#{self} find_rp_vm: unknown child type found: #{child.entity.class}"
-      end
+  def find_vms(container, vm_names)
+    vm_obj = []
+    vmview = vim.serviceContent.viewManager.CreateContainerView(
+      recursive: true, container: container,
+      type: ['VirtualMachine'])
+    vmview.view.each do |vm|
+      vm_obj << match_vm(vm_names, vm)
     end
-    @vm_obj.flatten
+    vmview.DestroyView
+    vm_obj.flatten
   end
 
   def cluster

--- a/lib/puppet/provider/vc_vm_group/default.rb
+++ b/lib/puppet/provider/vc_vm_group/default.rb
@@ -79,7 +79,6 @@ Puppet::Type.type(:vc_vm_group).provide(:vc_vm_group, :parent => Puppet::Provide
   end
 
   def find_vms(container, vm_names)
-    vm_obj = []
     vmview = vim.serviceContent.viewManager.CreateContainerView(
       recursive: true, container: container,
       type: ['VirtualMachine'])

--- a/lib/puppet/provider/vc_vm_group/default.rb
+++ b/lib/puppet/provider/vc_vm_group/default.rb
@@ -78,24 +78,14 @@ Puppet::Type.type(:vc_vm_group).provide(:vc_vm_group, :parent => Puppet::Provide
       end
   end
 
-  def match_vm(matches, vm)
-    matched_vms = []
-    matches.each do |match|
-      matched_vms << vm if vm.name == match
-    end
-    matched_vms
-  end
-
   def find_vms(container, vm_names)
     vm_obj = []
     vmview = vim.serviceContent.viewManager.CreateContainerView(
       recursive: true, container: container,
       type: ['VirtualMachine'])
-    vmview.view.each do |vm|
-      vm_obj << match_vm(vm_names, vm)
-    end
+    vm_obj = vmview.view.select { |vm| vm_names.include? vm.name }
     vmview.DestroyView
-    vm_obj.flatten
+    vm_obj
   end
 
   def cluster


### PR DESCRIPTION
- replace recursive vm find with view
- match vm names exactly to not have vms with similar names included in the group