### PR TITLE
Add valid types to mapping of nic_types in lib/puppet_x/vmware/mapper/virtual_ethernet_card_map.r

### DIFF
--- a/lib/puppet/provider/vm_nic/default.rb
+++ b/lib/puppet/provider/vm_nic/default.rb
@@ -179,16 +179,16 @@ Puppet::Type.type(:vm_nic).provide(:vm_nic, :parent => Puppet::Provider::Vcenter
       nicType = config_is_now.class.to_s
     end
 
-    deviceSpec = 
+    deviceSpec =
      begin
         case nicType
-        when :e1000, 'VirtualE1000'
+        when :e1000, 'VirtualE1000', :VirtualE1000
           RbVmomi::VIM::VirtualE1000( deviceSpec.props )
-        when :e1000e, 'VirtualE1000e'
+        when :e1000e, 'VirtualE1000e', :VirtualE1000e
           RbVmomi::VIM::VirtualE1000e( deviceSpec.props )
-        when :vmxnet2, 'VirtualVmxnet2'
+        when :vmxnet2, 'VirtualVmxnet2', :VirtualVmxnet2
           RbVmomi::VIM::VirtualVmxnet2( deviceSpec.props )
-        when :vmxnet3, 'VirtualVmxnet3'
+        when :vmxnet3, 'VirtualVmxnet3', :VirtualVmxnet3
           RbVmomi::VIM::VirtualVmxnet3( deviceSpec.props )
         end
      end
@@ -196,9 +196,8 @@ Puppet::Type.type(:vm_nic).provide(:vm_nic, :parent => Puppet::Provider::Vcenter
       :operation => operation,
       :device    => deviceSpec
     }
-
     virtualDeviceConfigSpec = RbVmomi::VIM::VirtualDeviceConfigSpec( spec )
-    
+
     @virtualMachineConfigSpec = RbVmomi::VIM::VirtualMachineConfigSpec(
       :deviceChange => [ virtualDeviceConfigSpec ]
     )

--- a/lib/puppet_x/vmware/mapper/virtual_ethernet_card_map.rb
+++ b/lib/puppet_x/vmware/mapper/virtual_ethernet_card_map.rb
@@ -12,7 +12,7 @@ module PuppetX::VMware::Mapper
         ],
         :type               => LeafData[
           :desc             => 'Virtual Ethernet Card Type',
-          :valid_enum       => [:e1000, :e1000e, :vmxnet2, :vmxnet3]
+          :valid_enum       => [:e1000, :e1000e, :vmxnet2, :vmxnet3, 'VirtualE1000', 'VirtualE1000e', 'VirtualVmxnet2', 'VirtualVmxnet3']
         ],
         :portgroup          => LeafData[
           :desc             => "The name of the portgroup this adapter is connected on"


### PR DESCRIPTION
lib/puppet_x/vmware/mapper/virtual_ethernet_card_map.rb

- Add teh below values to type[:valid_enum] array for
  virtual_ethernet_card_map
- Add corresonding values to device_spec when statement in
  lib/puppet/provider/vm_nic/default.rb